### PR TITLE
Upgrade Spring from 5.3.23 to 5.3.31

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	implementation 'org.springframework:spring-jms:5.2.6.RELEASE'
+	implementation 'org.springframework:spring-jms:5.3.31'
 
 	implementation 'org.yaml:snakeyaml:1.33'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.7.4'
+	id 'org.springframework.boot' version '2.7.18'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id "checkstyle"
@@ -42,9 +42,7 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 
 	// WebClient
-	implementation ('org.springframework.boot:spring-boot-starter-webflux:2.6.7') {
-		exclude group: 'io.netty', module: 'netty-codec'
-	}
+	implementation ('org.springframework.boot:spring-boot-starter-webflux:2.7.18')
 	implementation('org.projectreactor:reactor-spring:1.0.1.RELEASE') {
 		exclude group: 'com.jayway.jsonpath', module: 'json-path'
 	}
@@ -58,12 +56,8 @@ dependencies {
 
 	// Infrastructure
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.279'
-	implementation ('com.azure:azure-storage-blob:12.18.0') {
-		exclude group: 'io.netty', module: 'netty-codec'
-	}
-	implementation ('org.apache.qpid:qpid-jms-client:1.2.0') {
-		exclude group: 'io.netty', module: 'netty-codec-http'
-	}
+	implementation ('com.azure:azure-storage-blob:12.18.0')
+	implementation ('org.apache.qpid:qpid-jms-client:1.2.0')
 
 	// Utils
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
@@ -98,12 +92,6 @@ dependencies {
 		}
 		implementation('commons-io:commons-io:2.7') {
 			because 'to fix https://snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109'
-		}
-		implementation('io.netty:netty-codec-http:4.1.68.Final') {
-			because 'to fix SNYK-JAVA-IONETTY-1070799'
-		}
-		implementation('io.netty:netty-codec:4.1.68.Final') {
-			because 'to fix SNYK-JAVA-IONETTY-1584064'
 		}
 		implementation('org.apache.commons:commons-compress:1.21') {
 			because 'to fix SNYK-JAVA-ORGAPACHECOMMONS-1316638'


### PR DESCRIPTION
## Why

Having the latest version of Spring brings in the [latest security fixes](https://spring.io/blog/2023/11/16/spring-framework-5-3-31-and-6-0-14-available-now/).

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
