### PR TITLE
Upgrade lombok from 1.18.16 to 1.18.26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ service/out/*
 .vscode
 */out/
 out/
-lombok.config
 
 # env vars with credentials for development
 vars.sh*

--- a/mock-mhs-adaptor/build.gradle
+++ b/mock-mhs-adaptor/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.5.12'
 	id 'io.spring.dependency-management' version '1.0.10.RELEASE'
 	id 'java'
-	id "io.freefair.lombok" version "5.3.0"
+	id "io.freefair.lombok" version "6.6.3"
 }
 
 apply plugin: 'java'
@@ -22,10 +22,6 @@ dependencies {
 	implementation 'org.apache.qpid:qpid-jms-client:0.56.0'
 	implementation 'org.apache.commons:commons-lang3:3.11'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-}
-
-lombok {
-	config['lombok.log.fieldName'] = 'LOGGER'
 }
 
 test {

--- a/mock-mhs-adaptor/lombok.config
+++ b/mock-mhs-adaptor/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.log.fieldName = LOGGER

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'java'
 	id "checkstyle"
 	id "com.github.spotbugs" version "5.0.12"
-	id "io.freefair.lombok" version "5.3.0"
+	id "io.freefair.lombok" version "6.6.3"
 	id 'jacoco'
 }
 
@@ -18,10 +18,6 @@ mainClassName = ' uk.nhs.adaptors.gp2gp.Gp2gpApplication'
 
 group = 'uk.nhs.adaptors'
 sourceCompatibility = '11'
-
-lombok {
-	config['lombok.log.fieldName'] = 'LOGGER'
-}
 
 checkstyle {
 	toolVersion '8.38'

--- a/service/lombok.config
+++ b/service/lombok.config
@@ -1,0 +1,4 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true
+lombok.extern.findbugs.addSuppressFBWarnings = true
+lombok.log.fieldName = LOGGER


### PR DESCRIPTION
## Why

1.18.22 adds support for Java 17
See: https://projectlombok.org/changelog

Version 6 of io.freefair.lombok does not generate the config file automatically.
Instead commit the generated version from 5.3.
See: https://github.com/freefair/gradle-plugins/issues/379

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes