### PR TITLE
Remove unnecessary dependency version pinning

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -80,12 +80,6 @@ dependencies {
 	spotbugs 'com.github.spotbugs:spotbugs:4.7.3'
 
 	constraints {
-		implementation('com.google.guava:guava:30.1-jre') {
-			because 'hapi-fhir-structures-dstu3:5.2.1 depends on previous version with CVE-2020-8908'
-		}
-		implementation('commons-codec:commons-codec:1.15') {
-			because 'hapi-fhir-structures-dstu3:5.2.1 depends on previous version with SNYK-JAVA-COMMONSCODEC-561518'
-		}
 		implementation('commons-io:commons-io:2.7') {
 			because 'to fix https://snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109'
 		}


### PR DESCRIPTION
## Why

Package mentioned in description "hapi-fhir-structures-dstu3" has since been updated.

<details><pre>
+--- ca.uhn.hapi.fhir:hapi-fhir-structures-dstu3:5.4.0
|    +--- ca.uhn.hapi.fhir:hapi-fhir-base:5.4.0
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.12.3 -> 2.13.4.2 (*)
|    |    +--- org.apache.commons:commons-lang3:3.12.0
|    |    +--- org.apache.commons:commons-text:1.9 -> 1.10.0
|    |    |    \--- org.apache.commons:commons-lang3:3.12.0
|    |    +--- commons-codec:commons-codec:1.15
|    |    +--- commons-io:commons-io:2.8.0 -> 2.11.0
|    |    +--- com.google.guava:guava:30.1.1-jre
|    |    |    +--- com.google.guava:failureaccess:1.0.1
|    |    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
|    |    |    +--- com.google.code.findbugs:jsr305:3.0.2
|    |    |    +--- org.checkerframework:checker-qual:3.8.0
|    |    |    +--- com.google.errorprone:error_prone_annotations:2.5.1
|    |    |    \--- com.google.j2objc:j2objc-annotations:1.3
|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
|    |    +--- org.slf4j:jcl-over-slf4j:1.7.30 -> 1.7.36
|    |    |    \--- org.slf4j:slf4j-api:1.7.36
|    |    \--- com.google.code.findbugs:jsr305:3.0.2
|    +--- ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.4.0
|    |    +--- ca.uhn.hapi.fhir:hapi-fhir-base:5.4.0 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 -> 1.6.21
|    |         +--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21
|    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21
|    |         |    \--- org.jetbrains:annotations:13.0
|    |         \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21
|    |              \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.21 (*)
|    +--- ca.uhn.hapi.fhir:org.hl7.fhir.dstu3:5.4.0
|    |    +--- ca.uhn.hapi.fhir:org.hl7.fhir.utilities:5.4.0 (*)
|    |    +--- ca.uhn.hapi.fhir:hapi-fhir-base:5.4.0 (*)
|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0 -> 1.6.21 (*)
|    \--- commons-codec:commons-codec:1.1 -> 1.15
</pre></details>


## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
