### PR TITLE
NIAD-3007: Upgrade from Java 11 to 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,13 +66,15 @@ pipeline {
                                     spotBugs(pattern: 'build/reports/spotbugs/*.xml')
                                 ]
                             )
-                            step([
-                                $class : 'JacocoPublisher',
-                                execPattern : '**/build/jacoco/*.exec',
-                                classPattern : '**/build/classes/java',
-                                sourcePattern : 'src/main/java',
-                                exclusionPattern : '**/*Test.class'
-                            ])
+                            // Disable JacocoPublisher for now, as our Jenkins doesn't support Java 17
+                            // See NIAD-3022 for more details
+                            // step([
+                            //   $class : 'JacocoPublisher',
+                            //   execPattern : '**/build/jacoco/*.exec',
+                            //   classPattern : '**/build/classes/java',
+                            //   sourcePattern : 'src/main/java',
+                            //   exclusionPattern : '**/*Test.class'
+                            // ])
                             sh "rm -rf build"
                             sh "docker-compose -f docker/docker-compose.yml -f docker/docker-compose-tests.yml down"
                             sh "docker network rm commonforgp2gp"

--- a/developer-information.md
+++ b/developer-information.md
@@ -2,7 +2,7 @@
 
 ## Requirements:
 
-* JDK 11 - We develop the adaptor in Java with Spring Boot
+* JDK 17 - We develop the adaptor in Java with Spring Boot
 * Docker - We release the adaptor using Docker images on [Dockerhub](https://hub.docker.com/repository/docker/nhsdev/nia-gp2gp-adaptor)
 
 ## How to operate the adaptor

--- a/docker/e2e-tests/Dockerfile
+++ b/docker/e2e-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.4-jdk11
+FROM gradle:7.4-jdk17
 
 COPY --chown=gradle:gradle e2e-tests /home/gradle/e2e-tests
 

--- a/docker/mock-mhs-adaptor/Dockerfile
+++ b/docker/mock-mhs-adaptor/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.4-jdk11 AS build
+FROM gradle:7.4-jdk17 AS build
 
 COPY --chown=gradle:gradle mock-mhs-adaptor /home/gradle/mock-mhs-adaptor
 
@@ -10,7 +10,7 @@ FROM build AS package
 
 RUN gradle --build-cache bootJar
 
-FROM adoptopenjdk/openjdk11:jre
+FROM eclipse-temurin:17-jre-focal
 
 EXPOSE 8081
 

--- a/docker/service/Dockerfile
+++ b/docker/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.4-jdk11 AS build
+FROM gradle:7.4-jdk17 AS build
 
 COPY --chown=gradle:gradle service /home/gradle/service
 
@@ -10,7 +10,7 @@ FROM build AS package
 
 RUN gradle --build-cache bootJar
 
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:17-jre-focal
 
 EXPOSE 8080
 

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id "io.freefair.lombok" version "5.3.0"
+    id "io.freefair.lombok" version "6.6.3"
 }
 
 apply plugin: 'java'

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -6,7 +6,7 @@ plugins {
 apply plugin: 'java'
 
 group = 'uk.nhs.adaptors'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 repositories {
     mavenCentral()

--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
     testImplementation "org.assertj:assertj-core:3.18.1"
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
-    testImplementation 'org.xmlunit:xmlunit-assertj:2.8.2'
+    testImplementation 'org.xmlunit:xmlunit-assertj3:2.8.2'
     testImplementation 'org.xmlunit:xmlunit-matchers:2.8.2'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.1.3'
 

--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.commons.util.StringUtils;
-import org.xmlunit.assertj.XmlAssert;
+import org.xmlunit.assertj3.XmlAssert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;

--- a/mock-mhs-adaptor/build.gradle
+++ b/mock-mhs-adaptor/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
 
 group = 'uk.nhs.adaptors'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 repositories {
 	mavenCentral()

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'application'
 mainClassName = ' uk.nhs.adaptors.gp2gp.Gp2gpApplication'
 
 group = 'uk.nhs.adaptors'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 checkstyle {
 	toolVersion '8.38'


### PR DESCRIPTION
## Why

Upgrading to Java 17 allows us to upgrade to Spring Framework 6.1. We're currently on the latest version (5.3) which supports Java 11.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes