### PR TITLE
Update Docker Composes to use compatible images

### DIFF
--- a/docker/activemq/Dockerfile
+++ b/docker/activemq/Dockerfile
@@ -1,5 +1,4 @@
-FROM openjdk:17-jdk-alpine
-#FROM bellsoft/liberica-openjdk-alpine-musl:17 - ARM build
+FROM eclipse-temurin:21-jdk-alpine
 
 ENV ACTIVEMQ_VERSION 5.16.3
 ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION

--- a/docker/docker-compose-arm.yml
+++ b/docker/docker-compose-arm.yml
@@ -64,7 +64,7 @@ services:
   mongodb:
     networks: 
       - commonforgp2gp
-    image: mongo
+    image: mongo:3.6.23
     ports:
       - "27017:27017"
 

--- a/docker/docker-compose-transform-tool.yml
+++ b/docker/docker-compose-transform-tool.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   mongodb:
-    image: mongo
+    image: mongo:3.6.23
     ports:
       - "27017:27017"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,7 +66,7 @@ services:
   mongodb:
     networks: 
       - commonforgp2gp
-    image: bitnami/mongodb
+    image: mongo:3.6.23
     ports:
       - "27017:27017"
 


### PR DESCRIPTION
## What

Update mongo image for docker-compose to use a specific version which works with ARM/AMD64
Update JDK Version

## Why

To make docker composes work with both architectures

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings