### PR TITLE
Use same ActiveMQ image for M1 Macs as with x86 for consistency

### DIFF
--- a/docker/docker-compose-arm.yml
+++ b/docker/docker-compose-arm.yml
@@ -69,9 +69,10 @@ services:
       - "27017:27017"
 
   activemq:
-    networks: 
+    networks:
       - commonforgp2gp
-    image: nhsdev/nia-ps-activemq:0.1-arm64
+    build:
+      context: ./activemq
     ports:
       - "8161:8161"
       - "5672:5672"


### PR DESCRIPTION
## What

Activemq image changed to one that's working on m1 Macs.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
