### PR TITLE
NIAD-2394: Start storing the GP Connect document retrieval error message in Mongo

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentComponentTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentComponentTest.java
@@ -1,0 +1,69 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.nhs.adaptors.gp2gp.common.task.BaseTaskTest;
+import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+import uk.nhs.adaptors.gp2gp.testcontainers.ActiveMQExtension;
+import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.nhs.adaptors.gp2gp.ehr.EhrStatusConstants.DOCUMENT_ID;
+
+@ExtendWith({SpringExtension.class, MongoDBExtension.class, ActiveMQExtension.class})
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class GetAbsentAttachmentComponentTest extends BaseTaskTest {
+    @Autowired
+    private GetAbsentAttachmentTaskExecutor getAbsentAttachmentTaskExecutor;
+
+    @Autowired
+    private EhrExtractStatusRepository ehrExtractStatusRepository;
+
+    @Test
+    public void When_AbsentAttachmentTaskExecuted_Expect_DocumentRecordUpdatedWithErrorReason() {
+        var ehrExtractStatus = addEhrStatusToDatabase();
+        var taskDefinition = GetAbsentAttachmentTaskDefinition.builder()
+                .messageId(DOCUMENT_ID)
+                .title("This is the reason why the document won't be sent over GP2GP.")
+                .fromAsid(ehrExtractStatus.getEhrRequest().getFromAsid())
+                .toAsid(ehrExtractStatus.getEhrRequest().getToAsid())
+                .fromOdsCode(ehrExtractStatus.getEhrRequest().getFromOdsCode())
+                .toOdsCode(ehrExtractStatus.getEhrRequest().getToOdsCode())
+                .conversationId(ehrExtractStatus.getConversationId())
+                .requestId(ehrExtractStatus.getEhrRequest().getRequestId())
+                .taskId(UUID.randomUUID().toString())
+                .documentId(DOCUMENT_ID)
+                .build();
+        getAbsentAttachmentTaskExecutor.execute(taskDefinition);
+
+        var updatedEhrExtractStatus = ehrExtractStatusRepository
+            .findByConversationId(taskDefinition.getConversationId())
+            .orElseThrow();
+
+        assertThat(updatedEhrExtractStatus
+                .getGpcAccessDocument()
+                .getDocuments()
+                .get(0)
+                .getGpConnectErrorMessage())
+            .isEqualTo("This is the reason why the document won't be sent over GP2GP.");
+    }
+
+    private EhrExtractStatus addEhrStatusToDatabase() {
+        var ehrExtractStatus = EhrExtractStatusTestUtils.prepareEhrExtractStatus();
+        ehrExtractStatus.setGpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                .documents(List.of(EhrExtractStatus.GpcDocument.builder()
+                        .documentId(DOCUMENT_ID)
+                        .build()))
+                .build());
+        return ehrExtractStatusRepository.save(ehrExtractStatus);
+    }
+
+}

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentComponentTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentComponentTest.java
@@ -158,6 +158,7 @@ public class GetGpcDocumentComponentTest extends BaseTaskTest {
         assertThat(gpcDocuments.get(0).getAccessedAt()).isNotNull();
         assertThat(gpcDocuments.get(0).getObjectName()).isEqualTo(absentAttachmentFilename);
         assertThat(gpcDocuments.get(0).getMessageId()).isEqualTo(documentId);
+        assertThat(gpcDocuments.get(0).getGpConnectErrorMessage()).isEqualTo("The document could not be retrieved");
 
         assertDoesNotThrow(() -> storageConnector.downloadFromStorage(absentAttachmentFilename));
 
@@ -198,6 +199,7 @@ public class GetGpcDocumentComponentTest extends BaseTaskTest {
         assertThat(gpcDocument.getObjectName()).isEqualTo(EXPECTED_DOCUMENT_JSON_FILENAME);
         assertThat(gpcDocument.getAccessedAt()).isNotNull();
         assertThat(gpcDocument.getTaskId()).isEqualTo(taskDefinition.getTaskId());
+        assertThat(gpcDocument.getGpConnectErrorMessage()).isNull();
     }
 
     private List<EhrExtractStatus.GpcDocument> prepareDocuments() {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -168,11 +168,12 @@ public class EhrExtractStatusService {
     }
 
     public EhrExtractStatus updateEhrExtractStatusAccessDocument(
-        DocumentTaskDefinition documentTaskDefinition,
-        String documentName,
-        String taskId,
-        String messageId,
-        int base64ContentLength
+            DocumentTaskDefinition documentTaskDefinition,
+            String documentName,
+            String taskId,
+            String messageId,
+            int base64ContentLength,
+            String errorMessage
     ) {
         Query query = new Query();
         query.addCriteria(Criteria
@@ -186,6 +187,7 @@ public class EhrExtractStatusService {
         update.set(DOCUMENT_OBJECT_NAME_PATH, documentName);
         update.set(DOCUMENT_MESSAGE_ID_PATH, messageId);
         update.set(DOCUMENT_BASE64_CONTENT_LENGTH, base64ContentLength);
+        update.set(GPC_DOCUMENTS + ARRAY_REFERENCE + "gpConnectErrorMessage", errorMessage);
         FindAndModifyOptions returningUpdatedRecordOption = getReturningUpdatedRecordOption();
 
         EhrExtractStatus ehrExtractStatus = mongoTemplate.findAndModify(query, update, returningUpdatedRecordOption,

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
@@ -57,7 +57,15 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
         storageConnectorService.uploadFile(storageDataWrapperWithMhsOutboundRequest, fileName);
 
         return ehrExtractStatusService.updateEhrExtractStatusAccessDocument(
-            taskDefinition, fileName, taskId, messageId, fileContent.length()
+            taskDefinition, fileName, taskId, messageId, fileContent.length(), getTitle(taskDefinition)
         );
+    }
+
+    private String getTitle(DocumentTaskDefinition taskDefinition) {
+        if (taskDefinition.getTitle() != null) {
+            return taskDefinition.getTitle();
+        }
+
+        return "The document could not be retrieved";
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/model/EhrExtractStatus.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/model/EhrExtractStatus.java
@@ -91,6 +91,9 @@ public class EhrExtractStatus implements TimeToLive {
         private boolean isSkeleton;
         private List<Identifier> identifier;
         private String originalDescription;
+
+        // Error message generated when trying to fetch the document over GP Connect.
+        private String gpConnectErrorMessage;
     }
 
     @Data

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
@@ -75,7 +75,7 @@ public class GetGpcDocumentTaskExecutor implements TaskExecutor<GetGpcDocumentTa
         storageConnectorService.uploadFile(storageDataWrapperWithMhsOutboundRequest, documentName);
 
         return ehrExtractStatusService.updateEhrExtractStatusAccessDocument(
-            taskDefinition, documentName, taskId, taskDefinition.getMessageId(), contentAsBase64.length());
+            taskDefinition, documentName, taskId, taskDefinition.getMessageId(), contentAsBase64.length(), null);
     }
 
     private StorageDataWrapper getStorageDataWrapper(


### PR DESCRIPTION
## Why

This way we can refer back to this value at a later date. We plan to use this when sending out the XML EhrExtract to populate the AbsentAttachment details.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
