### PR TITLE
Bump the version of the GP Connect Consumer adaptor used

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - -global-response-templating
 
   gpcc:
-    image: nhsdev/nia-gpc-consumer-adaptor:0.3.3
+    image: nhsdev/nia-gpc-consumer-adaptor:0.3.4
     networks: 
       - commonforgp2gp
     ports:


### PR DESCRIPTION
## Why

This version has arm64 available, making performance on an M1 mac better.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
