### PR TITLE
Remove explicit versioning of spring dependencies

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -32,13 +32,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-	implementation 'org.springframework:spring-jms:5.3.31'
+	implementation 'org.springframework:spring-jms'
 
 	implementation 'org.yaml:snakeyaml:1.33'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
 
 	// WebClient
-	implementation ('org.springframework.boot:spring-boot-starter-webflux:2.7.18')
+	implementation ('org.springframework.boot:spring-boot-starter-webflux')
 	implementation('org.projectreactor:reactor-spring:1.0.1.RELEASE') {
 		exclude group: 'com.jayway.jsonpath', module: 'json-path'
 	}


### PR DESCRIPTION
## Why

[Version is managed by the gradle org.springframework.boot plugin](https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#managing-dependencies.dependency-management-plugin).

## Type of change

- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
