### PR TITLE
NIAD-2997: removal of unused ssp_from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix GpConnectException (ASID_CHECK_FAILED_MESSAGESENDER) being thrown, a correct ASID value is fetched in GP Connect Consumer Adapter 
+
 ## [1.5.14] - 2024-01-05
 
 ### Added 
@@ -35,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guard against possible null pointer error in exception handler.
 - Fix errors within the generation of compressed EHR Extracts (happens when the record becomes >5MB) which was causing
   SystmOne to reject the transfer.
-
 
 ## [1.5.11] - 2023-09-26
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/builder/GpcRequestBuilder.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/builder/GpcRequestBuilder.java
@@ -41,6 +41,7 @@ import static org.apache.http.protocol.HTTP.CONTENT_TYPE;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Slf4j
 public class GpcRequestBuilder {
+
     @Value("${gp2gp.gpc.overrideFromAsid}")
     private String overrideFromAsid;
     @Value("${gp2gp.gpc.overrideToAsid}")
@@ -130,34 +131,12 @@ public class GpcRequestBuilder {
     }
 
     private RequestBodySpec buildRequestWithHeaders(RequestBodySpec uri, TaskDefinition taskDefinition, String interactionId) {
-        /*
-         * SSP_FROM must be set to GP2GP ASID which is stored in the toAsid property of the task
-         * SSP_TO is left blank as it will be set in the GPC Consumer Proxy
-         */
+
         return uri.accept(MediaType.valueOf(FHIR_CONTENT_TYPE))
-            .header(SSP_FROM, getToAsid(taskDefinition.getToAsid()))
             .header(SSP_INTERACTION_ID, interactionId)
             .header(SSP_TRACE_ID, taskDefinition.getConversationId())
             .header(AUTHORIZATION, AUTHORIZATION_BEARER + gpcTokenBuilder.buildToken(taskDefinition.getFromOdsCode()))
             .header(CONTENT_TYPE, FHIR_CONTENT_TYPE);
-    }
-
-    private String getFromAsid(String fromAsid) {
-        if (StringUtils.isNotBlank(overrideFromAsid)) {
-            LOGGER.warn("GP2GP_GPC_OVERRIDE_FROM_ASID is being used, no longer using provided from asid");
-            return overrideFromAsid;
-        } else {
-            return fromAsid;
-        }
-    }
-
-    private String getToAsid(String toAsid) {
-        if (StringUtils.isNotBlank(overrideToAsid)) {
-            LOGGER.warn("GP2GP_GPC_OVERRIDE_TO_ASID is being used, no longer using provided to asid");
-            return overrideToAsid;
-        } else {
-            return toAsid;
-        }
     }
 
     private RequestHeadersSpec<?> buildRequestWithHeadersAndBody(RequestBodySpec uri, String requestBody,

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/builder/GpcRequestBuilder.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/builder/GpcRequestBuilder.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.parser.IParser;
 import io.netty.handler.ssl.SslContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.BooleanType;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Parameters;
@@ -49,7 +48,6 @@ public class GpcRequestBuilder {
 
     private static final String NHS_NUMBER_SYSTEM = "https://fhir.nhs.uk/Id/nhs-number";
     private static final String FHIR_CONTENT_TYPE = "application/fhir+json";
-    private static final String SSP_FROM = "Ssp-From";
     private static final String SSP_INTERACTION_ID = "Ssp-InteractionID";
     private static final String SSP_TRACE_ID = "Ssp-TraceID";
     private static final String AUTHORIZATION = "Authorization";


### PR DESCRIPTION
## What

"SSP_FROM" header is removed when a request is made to GP Connect. 

## Why

The value of "SSP_FROM" header will be set in GP Connect by querying SDS service.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
