### PR TITLE
 wiremock: Make the unknown NHS Number response configurable

### DIFF
--- a/docker/wiremock/README.md
+++ b/docker/wiremock/README.md
@@ -2,6 +2,8 @@
 
 ## Patients - `migratestructuredrecord` endpoint
 
+Each scenario below can be retrieved by requesting the associated NHS Number specified.
+
 ### Invalid/error responses
 - [OperationOutcome - Invalid NHS Number](stubs/__files/operationOutcomeInvalidNHSNumber.json) 123456789, 960000001
 - [OperationOutcome - Bad Request](stubs/__files/operationOutcomeBadRequest.json) 9600000005
@@ -11,7 +13,7 @@
 - [OperationOutcome - Invalid Resource](stubs/__files/operationOutcomeInvalidResource.json) 9600000003
 - [OperationOutcome - No Relationship](stubs/__files/operationOutcomeNoRelationship.json) 9600000010
 - [Bundle without Patient Resource](stubs/__files/malformedStructuredRecordMissingPatientResource.json) 2906543841
-- [OperationOutcome - Not Found](stubs/__files/operationOutcomePatientNotFound.json) 9600000009, also used as a fallback for any unrecognised NHS number.
+- [OperationOutcome - Not Found](stubs/__files/operationOutcomePatientNotFound.json) 9600000009
 
 ### Valid bundles
 
@@ -45,3 +47,24 @@
 - PWTP9 [EMIS](stubs/__files/EMISPatientStructurede2eResponsePWTP9.json) 9726908752 [TPP](stubs/__files/TPPPatientStructuredRecordE2EPWTP9.json) 9726908841
 - PWTP10 [EMIS](stubs/__files/EMISPatientStructurede2eResponsePWTP10.json) 9726908760 [TPP](stubs/__files/TPPPatientStructuredRecordE2EPWTP10.json) 9726908868
 - PWTP11 [EMIS](stubs/__files/EMISPatientStructurede2eResponsePWTP11.json) 9726908779 [TPP](stubs/__files/TPPPatientStructuredRecordE2EPWTP11.json) 9726908876
+
+
+## Patients - `migratestructuredrecord` endpoint, unknown patient
+
+The `migratestructuredrecord` endpoint will also respond to unknown NHS Numbers,
+by default returning a NOT FOUND response, but can also be set up to reply with
+a valid patient record.
+
+### Changing the default record
+
+To change the patient record returned to be [No Documents](stubs/__files/correctPatientNoDocsStructuredRecordResponse.json):
+
+```shell
+curl --request PUT --data '{"state": "No Documents"}' http://localhost:8110/__admin/scenarios/migrateStructuredRecord/state
+```
+
+To change the patient record returned to be NOT FOUND:
+
+```shell
+curl --request PUT --data '{"state": "Started"}' http://localhost:8110/__admin/scenarios/migrateStructuredRecord/state
+```

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP10.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP10.json
@@ -1175,7 +1175,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908760"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP11.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP11.json
@@ -1256,7 +1256,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908779"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP2.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP2.json
@@ -1204,7 +1204,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908671"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP3.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP3.json
@@ -925,7 +925,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908698"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP4.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP4.json
@@ -1640,7 +1640,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908701"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP5.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP5.json
@@ -1221,7 +1221,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908728"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP6.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP6.json
@@ -1437,7 +1437,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908736"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP7.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP7.json
@@ -1253,7 +1253,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908744"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP9.json
+++ b/docker/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP9.json
@@ -2082,7 +2082,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908752"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/MedicusBasedOnErrorStructuredRecord.json
+++ b/docker/wiremock/stubs/__files/MedicusBasedOnErrorStructuredRecord.json
@@ -81,7 +81,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9302014592"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP10.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP10.json
@@ -1175,7 +1175,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908868"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP11.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP11.json
@@ -1256,7 +1256,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908876"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP2.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP2.json
@@ -1204,7 +1204,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908787"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP3.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP3.json
@@ -925,7 +925,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908795"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP4.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP4.json
@@ -1640,7 +1640,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908809"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP5.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP5.json
@@ -1221,7 +1221,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908817"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP6.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP6.json
@@ -1437,7 +1437,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908825"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP7.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecordE2EPWTP7.json
@@ -1253,7 +1253,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908833"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/TPPPatientStructuredRecortdE2EPWTP9.json
+++ b/docker/wiremock/stubs/__files/TPPPatientStructuredRecortdE2EPWTP9.json
@@ -2082,7 +2082,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9726908841"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "name": [

--- a/docker/wiremock/stubs/__files/correctAllergiesContainedResourceResponse.json
+++ b/docker/wiremock/stubs/__files/correctAllergiesContainedResourceResponse.json
@@ -61,7 +61,7 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9728951256"
+            "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
           }
         ],
         "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientNoDocsStructuredRecordResponse.json
+++ b/docker/wiremock/stubs/__files/correctPatientNoDocsStructuredRecordResponse.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937294"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
@@ -117,7 +117,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937421"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponse3AbsentAttachmentDocuments.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponse3AbsentAttachmentDocuments.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937419"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponse3NormalDocuments.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponse3NormalDocuments.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937420"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseAbsentAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseAbsentAttachment.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937286"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseBodySite.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseBodySite.json
@@ -61,7 +61,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "1239577290"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseForLargeDocs.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseForLargeDocs.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937819"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseForLargeDocs2.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseForLargeDocs2.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937841"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseNormal.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseNormal.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937287"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneInvalidContentTypeAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneInvalidContentTypeAttachment.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9817280691"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneLargeDocOneNormal.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneLargeDocOneNormal.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937789"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithLargeDocxAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithLargeDocxAttachment.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9388098434"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
+++ b/docker/wiremock/stubs/__files/correctPatientStructuredRecordWithTextDocAttachment.json
@@ -81,7 +81,7 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9729649588"
+            "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
           }
         ],
         "active": true,

--- a/docker/wiremock/stubs/__files/malformedDateStructuredRecord.json
+++ b/docker/wiremock/stubs/__files/malformedDateStructuredRecord.json
@@ -97,7 +97,7 @@
                             }
                         ],
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937287"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 ],
                 "active": true,

--- a/docker/wiremock/stubs/__files/malformedStructuredRecordMissingPatientResource.json
+++ b/docker/wiremock/stubs/__files/malformedStructuredRecordMissingPatientResource.json
@@ -113,7 +113,7 @@
                 "subject": {
                     "identifier": {
                         "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": "9690937294"
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
                     }
                 },
                 "note": [

--- a/docker/wiremock/stubs/__files/operationOutcomePatientNotFound.json
+++ b/docker/wiremock/stubs/__files/operationOutcomePatientNotFound.json
@@ -18,7 +18,7 @@
           }
         ]
       },
-      "diagnostics": "No patient details found for patient ID: 9600000001"
+      "diagnostics": "No patient details found for patient ID: {{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
     }
   ]
 }

--- a/docker/wiremock/stubs/__files/patientWithNoDocumentResources.json
+++ b/docker/wiremock/stubs/__files/patientWithNoDocumentResources.json
@@ -96,7 +96,7 @@
               }
             ],
             "system": "https://fhir.nhs.uk/Id/nhs-number",
-            "value": "9690937294"
+            "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
           }
         ],
         "active": true,

--- a/docker/wiremock/stubs/mappings/migrateStructuredRecord No Documents.json
+++ b/docker/wiremock/stubs/mappings/migrateStructuredRecord No Documents.json
@@ -1,12 +1,14 @@
 {
   "priority": 2,
+  "scenarioName": "migrateStructuredRecord",
+  "requiredScenarioState": "No Documents",
   "request": {
     "method": "POST",
     "urlPattern": "/.*/STU3/1/gpconnect/fhir/Patient/[$]gpc[.]migratestructuredrecord"
   },
   "response": {
-    "status": 404,
-    "bodyFileName": "operationOutcomePatientNotFound.json",
+    "status": 200,
+    "bodyFileName": "correctPatientNoDocsStructuredRecordResponse.json",
     "headers": {
       "Server": "nginx",
       "Date": "{{now format='E, d MMM y HH:mm:ss z'}}",

--- a/docker/wiremock/stubs/mappings/migrateStructuredRecord Started.json
+++ b/docker/wiremock/stubs/mappings/migrateStructuredRecord Started.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "scenarioName": "migrateStructuredRecord",
+  "requiredScenarioState": "Started",
+  "request": {
+    "method": "POST",
+    "urlPattern": "/.*/STU3/1/gpconnect/fhir/Patient/[$]gpc[.]migratestructuredrecord"
+  },
+  "response": {
+    "status": 404,
+    "bodyFileName": "operationOutcomePatientNotFound.json",
+    "headers": {
+      "Server": "nginx",
+      "Date": "{{now format='E, d MMM y HH:mm:ss z'}}",
+      "Content-Type": "application/fhir+json;charset=UTF-8",
+      "Transfer-Encoding": "chunked",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-store",
+      "X-Powered-By": "HAPI FHIR 3.0.0 REST Server (FHIR Server; FHIR 3.0.1/DSTU3)",
+      "Strict-Transport-Security":"max-age=31536000"
+    }
+  }
+}


### PR DESCRIPTION
## Why

This will allow us to return canned responses for any NHS number, making testing easier when we can't control the NHS number.

The most obvious scenario where we can't control the NHS Number is in INT environment where the NHS numbers are managed centrally.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
