### PR TITLE
Remove volumes, orphans and all images when clearing up in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,7 +169,7 @@ pipeline {
     }  //Stages
     post {
         always {
-            sh label: 'Remove images created by docker-compose', script: 'docker-compose -f docker/docker-compose.yml -f docker/docker-compose-tests.yml down --rmi local'
+            sh label: 'Remove images created by docker-compose', script: 'docker-compose -f docker/docker-compose.yml -f docker/docker-compose-tests.yml down --rmi all --remove-orphans --volumes'
             sh label: 'Remove exited containers', script: 'docker container prune --force'
             sh label: 'Remove images tagged with current BUILD_TAG', script: 'docker image rm -f $(docker images "*/*:*${BUILD_TAG}" -q) $(docker images "*/*/*:*${BUILD_TAG}" -q) || true'
         }


### PR DESCRIPTION
## What

Remove volumes, orphans and all images when clearing up in Jenkins

## Why

We get worker nodes getting disk full errors, and by clearing more thoroughly this should be less of an issue.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users