### PR TITLE
Remove dependency override for testcontainers

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -60,9 +60,7 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation "org.assertj:assertj-core:3.24.2"
-	testImplementation ("org.testcontainers:testcontainers:1.16.3") {
-		exclude group: 'org.apache.commons', module: 'commons-compress'
-	}
+	testImplementation 'org.testcontainers:testcontainers:1.16.3'
 	testImplementation 'org.awaitility:awaitility:4.2.0'
 	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
 	testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:2.27.2'
@@ -75,9 +73,6 @@ dependencies {
 	constraints {
 		implementation('commons-io:commons-io:2.7') {
 			because 'to fix https://snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109'
-		}
-		implementation('org.apache.commons:commons-compress:1.21') {
-			because 'to fix SNYK-JAVA-ORGAPACHECOMMONS-1316638'
 		}
 		implementation('com.azure:azure-core-http-netty:1.9.1') {
 			because 'to fix SNYK-JAVA-IONETTY-1083991'


### PR DESCRIPTION
## Why

The version we're using already has the specified version of commons-compress

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
