### PR TITLE
Remove json-path downgrade

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -39,13 +39,6 @@ dependencies {
 
 	// WebClient
 	implementation ('org.springframework.boot:spring-boot-starter-webflux')
-	implementation('org.projectreactor:reactor-spring:1.0.1.RELEASE') {
-		exclude group: 'com.jayway.jsonpath', module: 'json-path'
-	}
-	implementation('com.jayway.jsonpath:json-path:2.5.0') {
-		exclude group: 'net.minidev', module: 'json-smart'
-	}
-	implementation('net.minidev:json-smart:2.4.7')
 
 	// Logging
 	implementation 'ch.qos.logback:logback-classic:1.2.9'


### PR DESCRIPTION
## Why

Versioning of reactor netty dependendency is already managed as part of the spring-boot-starter-webflux package, which is in turn versioned as part of Spring Framework version.

By having this explicit dependency we were downgrading the version of json-path in use.

This resolves a high CVE in json-smart

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
