### PR TITLE
Remove deprecated package from e2e-tests gradle

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     implementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4'
     testImplementation 'commons-io:commons-io:2.6'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'

--- a/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
+++ b/e2e-tests/src/test/java/uk/nhs/adaptors/gp2gp/e2e/EhrExtractTest.java
@@ -36,7 +36,6 @@ import org.junit.platform.commons.util.StringUtils;
 import org.xmlunit.assertj3.XmlAssert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import uk.nhs.adaptors.gp2gp.MessageQueue;
 import uk.nhs.adaptors.gp2gp.Mongo;
@@ -708,8 +707,7 @@ public class EhrExtractTest {
                 }
             });
 
-            ObjectMapper objectMapper = new ObjectMapper()
-                .registerModule(new JavaTimeModule());
+            ObjectMapper objectMapper = new ObjectMapper();
 
             return objectMapper.readValue(response, EhrStatus.class);
         }


### PR DESCRIPTION
## Why

This package isn't required as we're using Java17

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
