### PR TITLE
Fix invalid units of measure within wiremock stubs

### DIFF
--- a/docker/gpc-api-mock/stubs/__files/9690937286.structuredRecord.json
+++ b/docker/gpc-api-mock/stubs/__files/9690937286.structuredRecord.json
@@ -10087,9 +10087,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -14759,9 +14759,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -17453,9 +17453,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/docker/gpc-api-mock/stubs/__files/9690937287.structuredRecord.json
+++ b/docker/gpc-api-mock/stubs/__files/9690937287.structuredRecord.json
@@ -8227,9 +8227,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12060,9 +12060,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14299,9 +14299,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/docker/gpcc-mock/stubs/__files/9690937286.structuredRecord.json
+++ b/docker/gpcc-mock/stubs/__files/9690937286.structuredRecord.json
@@ -10087,9 +10087,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -14759,9 +14759,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -17453,9 +17453,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/docker/gpcc-mock/stubs/__files/9690937287.structuredRecord.json
+++ b/docker/gpcc-mock/stubs/__files/9690937287.structuredRecord.json
@@ -8227,9 +8227,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12060,9 +12060,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14299,9 +14299,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/docker/integration-wiremock/stubs/__files/9388098431.structuredRecord.json
+++ b/docker/integration-wiremock/stubs/__files/9388098431.structuredRecord.json
@@ -8227,9 +8227,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12060,9 +12060,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14299,9 +14299,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/docker/integration-wiremock/stubs/__files/9388098432.structuredRecord.json
+++ b/docker/integration-wiremock/stubs/__files/9388098432.structuredRecord.json
@@ -8227,9 +8227,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12060,9 +12060,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14299,9 +14299,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/docker/integration-wiremock/stubs/__files/9388098433.structuredRecord.json
+++ b/docker/integration-wiremock/stubs/__files/9388098433.structuredRecord.json
@@ -8227,9 +8227,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12060,9 +12060,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14299,9 +14299,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientNoDocsStructuredRecordResponse.json
+++ b/wiremock/stubs/__files/correctPatientNoDocsStructuredRecordResponse.json
@@ -2760,9 +2760,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -6541,9 +6541,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -7705,9 +7705,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
@@ -10117,9 +10117,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -14789,9 +14789,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -17483,9 +17483,9 @@
                 "valueQuantity":
                 {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponse3AbsentAttachmentDocuments.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponse3AbsentAttachmentDocuments.json
@@ -8233,9 +8233,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12066,9 +12066,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14305,9 +14305,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponse3NormalDocuments.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponse3NormalDocuments.json
@@ -8233,9 +8233,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12066,9 +12066,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14305,9 +14305,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponseAbsentAttachment.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponseAbsentAttachment.json
@@ -8233,9 +8233,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12066,9 +12066,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14305,9 +14305,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponseNormal.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponseNormal.json
@@ -8233,9 +8233,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12066,9 +12066,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14305,9 +14305,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneInvalidContentTypeAttachment.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneInvalidContentTypeAttachment.json
@@ -7992,9 +7992,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -11825,9 +11825,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14064,9 +14064,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneLargeDocOneNormal.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponseOneLargeDocOneNormal.json
@@ -8233,9 +8233,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12066,9 +12066,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14305,9 +14305,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/correctPatientStructuredRecordWithLargeDocxAttachment.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordWithLargeDocxAttachment.json
@@ -7992,9 +7992,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -11825,9 +11825,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14064,9 +14064,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/malformedDateStructuredRecord.json
+++ b/wiremock/stubs/__files/malformedDateStructuredRecord.json
@@ -8233,9 +8233,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -12066,9 +12066,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -14305,9 +14305,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },

--- a/wiremock/stubs/__files/malformedStructuredRecordMissingPatientResource.json
+++ b/wiremock/stubs/__files/malformedStructuredRecordMissingPatientResource.json
@@ -2644,9 +2644,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 },
                 "comment": "Chest clear"
             }
@@ -6477,9 +6477,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },
@@ -7641,9 +7641,9 @@
                 ],
                 "valueQuantity": {
                     "value": 16,
-                    "unit": "breaths per minute",
+                    "unit": "Breaths / minute",
                     "system": "http://unitsofmeasure.org",
-                    "code": "{resps}/min"
+                    "code": "{Breaths}/min"
                 }
             }
         },


### PR DESCRIPTION
## Why

When sent to another GP system, these invalid units of measures are rejected causing the transfer to fail.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
