### PR TITLE
/e2e-tests Netty constraints are fulfilled by updated packages

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -29,15 +29,6 @@ dependencies {
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
-
-    constraints {
-        implementation('io.netty:netty-codec-http:4.1.59.Final') {
-            because 'to fix SNYK-JAVA-IONETTY-1070799'
-        }
-        implementation('io.netty:netty-handler:4.1.59.Final') {
-            because 'to fix SNYK-JAVA-IONETTY-1042268'
-        }
-    }
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
## Why

These constraints are unnecessary, as Gradle is using 4.1.60 instead.

```
+--- io.netty:netty-handler:4.1.59.Final -> 4.1.60.Final (c)
\--- io.netty:netty-codec-http:4.1.59.Final -> 4.1.60.Final (c)
```

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
