### PR TITLE
Replace logback-classic dependency with spring-boot-starter-logging

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	implementation ('org.springframework.boot:spring-boot-starter-webflux')
 
 	// Logging
-	implementation 'ch.qos.logback:logback-classic:1.4.14'
+	implementation 'org.springframework.boot:spring-boot-starter-logging'
 
 	// Infrastructure
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.673'


### PR DESCRIPTION
## Why

This will reduce the dependencies we have to keep up to date, as Spring can maintain that.

We can instead focus on keeping Spring up to date and trust that they are patching logback-classic as and when required.

```
+--- org.springframework.boot:spring-boot-starter-logging:3.2.4
|    +--- ch.qos.logback:logback-classic:1.4.14
|    |    +--- ch.qos.logback:logback-core:1.4.14
|    |    \--- org.slf4j:slf4j-api:2.0.7 -> 2.0.12
```

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
