### PR TITLE
Remove unnecessary specification of spotbugs version

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -65,8 +65,6 @@ dependencies {
 	testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:3.0.1'
 	testImplementation 'com.squareup.okhttp3:okhttp:4.12.0'
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
-
-	spotbugs 'com.github.spotbugs:spotbugs:4.8.3'
 }
 
 test {


### PR DESCRIPTION
## Why

We already version the spotbugs Gradle plugin which comes with a default version of Spotbugs alongside it.

See this table for the mappings:
https://github.com/spotbugs/spotbugs-gradle-plugin?tab=readme-ov-file#spotbugs-version-mapping

Given that there is nothing stopping us from using the latest version of the Gradle plugin, we should focus on keeping that up to date.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
