### PR TITLE
Refactor updateEhrExtractStatusAccessDocumentDocumentReferences to pass in conversationId

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -117,18 +117,20 @@ public class EhrExtractStatusServiceTest {
     }
 
     @Test
-    public void When_updateEhrExtractStatusAccessDocumentDocumentReferences_Expect_DocumentAddedToMongoDb() {
+    public void When_UpdateEhrExtractStatusAccessDocumentDocumentReferences_Expect_DocumentAddedToMongoDb() {
         var ehrStatus = addCompleteTransfer();
 
         ehrExtractStatusService.updateEhrExtractStatusAccessDocumentDocumentReferences(
-            ehrStatus.getConversationId(), List.of(EhrExtractStatus.GpcDocument.builder().documentId("f368d574-b2aa-4255-9d98-97cca1d3502e").build()));
+            ehrStatus.getConversationId(), List.of(EhrExtractStatus.GpcDocument.builder()
+                .documentId("f368d574-b2aa-4255-9d98-97cca1d3502e").build()));
 
         assertThat(ehrExtractStatusRepository.findByConversationId(
             ehrStatus.getConversationId()).orElseThrow().getGpcAccessDocument().getDocuments().size())
             .isEqualTo(1);
 
         ehrExtractStatusService.updateEhrExtractStatusAccessDocumentDocumentReferences(
-            ehrStatus.getConversationId(), List.of(EhrExtractStatus.GpcDocument.builder().documentId("f368d574-b2aa-4255-9d98-97cca1d3502b").build()));
+            ehrStatus.getConversationId(), List.of(EhrExtractStatus.GpcDocument.builder()
+                .documentId("f368d574-b2aa-4255-9d98-97cca1d3502b").build()));
 
         assertThat(ehrExtractStatusRepository.findByConversationId(
             ehrStatus.getConversationId()).orElseThrow().getGpcAccessDocument().getDocuments().size())

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -116,6 +116,25 @@ public class EhrExtractStatusServiceTest {
         assertThat(returnedConversationIds).isEqualTo(inProgressConversationIds);
     }
 
+    @Test
+    public void When_updateEhrExtractStatusAccessDocumentDocumentReferences_Expect_DocumentAddedToMongoDb() {
+        var ehrStatus = addCompleteTransfer();
+
+        ehrExtractStatusService.updateEhrExtractStatusAccessDocumentDocumentReferences(
+            ehrStatus.getConversationId(), List.of(EhrExtractStatus.GpcDocument.builder().documentId("f368d574-b2aa-4255-9d98-97cca1d3502e").build()));
+
+        assertThat(ehrExtractStatusRepository.findByConversationId(
+            ehrStatus.getConversationId()).orElseThrow().getGpcAccessDocument().getDocuments().size())
+            .isEqualTo(1);
+
+        ehrExtractStatusService.updateEhrExtractStatusAccessDocumentDocumentReferences(
+            ehrStatus.getConversationId(), List.of(EhrExtractStatus.GpcDocument.builder().documentId("f368d574-b2aa-4255-9d98-97cca1d3502b").build()));
+
+        assertThat(ehrExtractStatusRepository.findByConversationId(
+            ehrStatus.getConversationId()).orElseThrow().getGpcAccessDocument().getDocuments().size())
+            .isEqualTo(2);
+    }
+
     private void addInProgressTransfer(String conversationId) {
         EhrExtractStatus extractStatus = EhrExtractStatus.builder()
             .ackPending(buildPositiveAckPending())
@@ -234,7 +253,7 @@ public class EhrExtractStatusServiceTest {
         ehrExtractStatusRepository.save(extractStatus);
     }
 
-    public void addCompleteTransfer() {
+    public EhrExtractStatus addCompleteTransfer() {
         String ehrMessageRef = generateRandomUppercaseUUID();
 
         EhrExtractStatus extractStatus = EhrExtractStatus.builder()
@@ -282,8 +301,7 @@ public class EhrExtractStatusServiceTest {
             .updatedAt(FIVE_DAYS_AGO)
             .build();
 
-        ehrExtractStatusRepository.save(extractStatus);
-
+        return ehrExtractStatusRepository.save(extractStatus);
     }
 
     private String generateRandomUppercaseUUID() {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -330,10 +330,10 @@ public class EhrExtractStatusService {
     }
 
     public void updateEhrExtractStatusAccessDocumentDocumentReferences(
-        GetGpcStructuredTaskDefinition documentReferencesTaskDefinition,
+        String conversationId,
         List<EhrExtractStatus.GpcDocument> documents
     ) {
-        Query query = createQueryForConversationId(documentReferencesTaskDefinition.getConversationId());
+        Query query = createQueryForConversationId(conversationId);
 
         Update.AddToSetBuilder updateBuilder = createUpdateWithUpdatedAt().addToSet(GPC_DOCUMENTS);
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
@@ -173,7 +173,7 @@ public class GetGpcStructuredTaskExecutor implements TaskExecutor<GetGpcStructur
                 .forEach(ehrStatusGpcDocuments::add);
 
             ehrExtractStatusService.updateEhrExtractStatusAccessDocumentDocumentReferences(
-                structuredTaskDefinition, ehrStatusGpcDocuments
+                structuredTaskDefinition.getConversationId(), ehrStatusGpcDocuments
             );
             queueGetDocumentsTask(structuredTaskDefinition, documentsAsExternalAttachments);
             queueGetAbsentAttachmentTask(structuredTaskDefinition, absentAttachments);


### PR DESCRIPTION

## What

Refactor updateEhrExtractStatusAccessDocumentDocumentReferences  in EHR Extract status service to pass in conversationId.

## Why

Currently it passes in an object and just extracts the conversationId from that.  It is simpler and easy to test if we just pass in the conversationId instead

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
