### PR TITLE
Simplify the EhrDocumentMapper to have one public method with two overloads

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/DocumentToMHSTranslator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/DocumentToMHSTranslator.java
@@ -33,12 +33,18 @@ public class DocumentToMHSTranslator {
     }
 
     private String createOutboundMessage(DocumentTaskDefinition taskDefinition, String base64Content, String contentType) {
-        var ehrDocumentTemplateParameters = ehrDocumentMapper
-            .mapToMhsPayloadTemplateParameters(taskDefinition, contentType);
-        var xmlContent = ehrDocumentMapper.mapMhsPayloadTemplateToXml(ehrDocumentTemplateParameters);
-
         try {
-            return prepareOutboundMessage(taskDefinition, base64Content, MimeTypes.OCTET_STREAM, xmlContent);
+            return prepareOutboundMessage(
+                taskDefinition,
+                base64Content,
+                MimeTypes.OCTET_STREAM,
+                ehrDocumentMapper.generateMhsPayload(
+                    taskDefinition,
+                    taskDefinition.getMessageId(),
+                    taskDefinition.getDocumentId(),
+                    contentType
+                )
+            );
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException(e);
         }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskExecutor.java
@@ -105,10 +105,18 @@ public class GetGpcStructuredTaskExecutor implements TaskExecutor<GetGpcStructur
                 externalAttachments.add(largeEhrExtractXmlAsExternalAttachment);
 
                 var getDocumentTaskDefinition = buildGetDocumentTask(structuredTaskDefinition, largeEhrExtractXmlAsExternalAttachment);
-                var mhsPayload = ehrDocumentMapper.mapMhsPayloadTemplateToXml(
-                        ehrDocumentMapper.mapToMhsPayloadTemplateParameters(getDocumentTaskDefinition, XML_CONTENT_TYPE));
 
-                uploadToStorage(ehrExtractXml, mhsPayload, fileName, getDocumentTaskDefinition);
+                uploadToStorage(
+                    ehrExtractXml,
+                    ehrDocumentMapper.generateMhsPayload(
+                        getDocumentTaskDefinition,
+                        getDocumentTaskDefinition.getMessageId(),
+                        getDocumentTaskDefinition.getDocumentId(),
+                        XML_CONTENT_TYPE
+                    ),
+                    fileName,
+                    getDocumentTaskDefinition
+                );
                 ehrStatusGpcDocuments.add(EhrExtractStatus.GpcDocument.builder()
                         .documentId(documentId)
                         .accessDocumentUrl(null)

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/EhrDocumentMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/EhrDocumentMapperTest.java
@@ -3,26 +3,20 @@ package uk.nhs.adaptors.gp2gp.gpc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.time.Instant;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.service.TimestampService;
 import uk.nhs.adaptors.gp2gp.ehr.EhrDocumentMapper;
-import uk.nhs.adaptors.gp2gp.ehr.model.EhrDocumentTemplateParameters;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class EhrDocumentMapperTest {
     private static final String TEST_FILE_DIRECTORY = "/gpc/output/";
     private static final String EXPECTED_XML_TO_JSON_FILE = "ExpectedEhrDocument.xml";
@@ -37,21 +31,10 @@ public class EhrDocumentMapperTest {
     private static final String TEST_ID = "test-id";
     private static final String TEST_DATE_TIME = "2020-01-01T01:01:01.01Z";
     private static final String TEXT_PLAIN = "text/plain";
+    private static final String TEST_FILENAME = "test-document-id.txt";
 
-    private static String expectedJsonToXmlContent;
-    private static GetGpcDocumentTaskDefinition getGpcDocumentTaskDefinition;
-
-    private EhrDocumentMapper ehrDocumentMapper;
-
-    @Mock
-    private TimestampService timestampService;
-    @Mock
-    private RandomIdGeneratorService randomIdGeneratorService;
-
-    @BeforeAll
-    public static void initialize() throws IOException {
-        expectedJsonToXmlContent = ResourceTestFileUtils.getFileContent(TEST_FILE_DIRECTORY + EXPECTED_XML_TO_JSON_FILE);
-        getGpcDocumentTaskDefinition = GetGpcDocumentTaskDefinition.builder()
+    private final String expectedJsonToXmlContent = ResourceTestFileUtils.getFileContent(TEST_FILE_DIRECTORY + EXPECTED_XML_TO_JSON_FILE);
+    private final GetGpcDocumentTaskDefinition getGpcDocumentTaskDefinition = GetGpcDocumentTaskDefinition.builder()
             .conversationId(TEST_CONVERSATION_ID)
             .messageId(TEST_MESSAGE_ID)
             .requestId(TEST_REQUEST_ID)
@@ -61,7 +44,13 @@ public class EhrDocumentMapperTest {
             .toOdsCode(TEST_TO_ODS_CODE)
             .documentId(TEST_DOCUMENT_ID)
             .build();
-    }
+
+    private EhrDocumentMapper ehrDocumentMapper;
+
+    @Mock
+    private TimestampService timestampService;
+    @Mock
+    private RandomIdGeneratorService randomIdGeneratorService;
 
     @BeforeEach
     public void setUp() {
@@ -71,11 +60,21 @@ public class EhrDocumentMapperTest {
     }
 
     @Test
-    public void When_MappingProperJsonRequestBody_Expect_ProperXmlOutput() {
-        EhrDocumentTemplateParameters ehrDocumentTemplateParameters =
-            ehrDocumentMapper.mapToMhsPayloadTemplateParameters(getGpcDocumentTaskDefinition, TEXT_PLAIN);
-        String output = ehrDocumentMapper.mapMhsPayloadTemplateToXml(ehrDocumentTemplateParameters);
+    public void When_MappingJsonRequestBody_WithDocumentId_Expect_XmlOutput() {
+        assertThat(ehrDocumentMapper.generateMhsPayload(
+            getGpcDocumentTaskDefinition,
+            TEST_MESSAGE_ID,
+            TEST_DOCUMENT_ID,
+            TEXT_PLAIN
+        )).isEqualToIgnoringWhitespace(expectedJsonToXmlContent);
+    }
 
-        assertThat(output).isEqualToIgnoringWhitespace(expectedJsonToXmlContent);
+    @Test
+    public void When_MappingJsonRequestBody_WithFilename_Expect_XmlOutput() {
+        assertThat(ehrDocumentMapper.generateMhsPayload(
+                getGpcDocumentTaskDefinition,
+                TEST_MESSAGE_ID,
+                TEST_FILENAME
+        )).isEqualToIgnoringWhitespace(expectedJsonToXmlContent);
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/ResourceTestFileUtils.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/ResourceTestFileUtils.java
@@ -1,14 +1,15 @@
 package uk.nhs.adaptors.gp2gp.utils;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import lombok.SneakyThrows;
 import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
 
 public class ResourceTestFileUtils {
-    public static String getFileContent(String filePath) throws IOException {
+    @SneakyThrows
+    public static String getFileContent(String filePath) {
         try (InputStream is = ResourceTestFileUtils.class.getResourceAsStream(filePath)) {
             if (is == null) {
                 throw new FileNotFoundException(filePath);


### PR DESCRIPTION
## Why

This makes calling the EhrDocumentMapper simpler, and consolidates the behaviour which was previously spread around into one class.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
