### PR TITLE
Update the MongoDB field with actual filename

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -132,7 +133,7 @@ public class EhrExtractStatusServiceTest {
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_Expect_DocumentRecordUpdated() {
         when(timestampService.now()).thenReturn(NOW);
-        var ehrStatus = addCompleteTransferWithDocuments();
+        var ehrStatus = addCompleteTransferWithDocument();
 
         updateEhrExtractStatusAccessDocument(ehrStatus.getConversationId(), DOCUMENT_ID);
 
@@ -144,7 +145,8 @@ public class EhrExtractStatusServiceTest {
             () -> assertThat(actual.getObjectName()).isEqualTo("this is a storage path.path"),
             () -> assertThat(actual.getMessageId()).isEqualTo("988290"),
             () -> assertThat(actual.getContentLength()).isEqualTo(1),
-            () -> assertThat(actual.getGpConnectErrorMessage()).isEqualTo("This is a fantastic error message")
+            () -> assertThat(actual.getGpConnectErrorMessage()).isEqualTo("This is a fantastic error message"),
+            () -> assertThat(actual.getFileName()).isEqualTo("NewUpdatedFileName.txt")
         );
     }
 
@@ -158,13 +160,14 @@ public class EhrExtractStatusServiceTest {
                 .build(),
             "this is a storage path.path",
             1,
-            "This is a fantastic error message"
+            "This is a fantastic error message",
+            "NewUpdatedFileName.txt"
         );
     }
 
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_With_InvalidConversationId_Expect_ThrowsException() {
-        addCompleteTransferWithDocuments();
+        addCompleteTransferWithDocument();
 
         assertThrows(
             EhrExtractException.class,
@@ -174,7 +177,7 @@ public class EhrExtractStatusServiceTest {
 
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_With_InvalidDocumentId_Expect_ThrowsException() {
-        final var ehrStatus = addCompleteTransferWithDocuments();
+        final var ehrStatus = addCompleteTransferWithDocument();
 
         assertThrows(
             EhrExtractException.class,
@@ -186,7 +189,7 @@ public class EhrExtractStatusServiceTest {
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_Expect_ReturnsUpdatedEhrStatusRecord() {
         when(timestampService.now()).thenReturn(NOW);
-        var ehrStatus = addCompleteTransferWithDocuments();
+        var ehrStatus = addCompleteTransferWithDocument();
 
         final var returnedRecord = updateEhrExtractStatusAccessDocument(ehrStatus.getConversationId(), DOCUMENT_ID);
 
@@ -334,59 +337,17 @@ public class EhrExtractStatusServiceTest {
         ehrExtractStatusRepository.save(extractStatus);
     }
 
-    public EhrExtractStatus addCompleteTransfer() {
-        String ehrMessageRef = generateRandomUppercaseUUID();
-
-        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
-            .ackHistory(EhrExtractStatus.AckHistory.builder()
-                .acks(List.of(
-                    EhrExtractStatus.EhrReceivedAcknowledgement.builder()
-                        .rootId(generateRandomUppercaseUUID())
-                        .received(FIVE_DAYS_AGO)
-                        .conversationClosed(FIVE_DAYS_AGO)
-                        .messageRef(ehrMessageRef)
-                        .build()))
-                .build())
-            .ackPending(EhrExtractStatus.AckPending.builder()
-                .messageId(generateRandomUppercaseUUID())
-                .taskId(generateRandomUppercaseUUID())
-                .typeCode(ACK_TYPE)
-                .updatedAt(FIVE_DAYS_AGO.toString())
-                .build())
-            .ackToRequester(buildPositiveAckToRequester())
-            .conversationId(generateRandomUppercaseUUID())
-            .created(FIVE_DAYS_AGO)
-            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
-                .sentAt(FIVE_DAYS_AGO)
-                .build())
-            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
-                .sentAt(FIVE_DAYS_AGO)
-                .taskId(generateRandomUppercaseUUID())
-                .build())
-            .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder()
-                .conversationClosed(FIVE_DAYS_AGO)
-                .messageRef(ehrMessageRef)
-                .received(FIVE_DAYS_AGO)
-                .rootId(generateRandomUppercaseUUID())
-                .build())
-            .ehrRequest(buildEhrRequest())
-            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
-                .documents(new ArrayList<>())
-                .build())
-            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
-                .accessedAt(FIVE_DAYS_AGO)
-                .objectName(generateRandomUppercaseUUID() + ".json")
-                .taskId(generateRandomUppercaseUUID())
-                .build())
-            .messageTimestamp(FIVE_DAYS_AGO)
-            .updatedAt(FIVE_DAYS_AGO)
-            .build();
-
-        return ehrExtractStatusRepository.save(extractStatus);
+    private EhrExtractStatus addCompleteTransfer() {
+        return addCompleteTransferWithDocuments(List.of());
     }
 
+    private EhrExtractStatus addCompleteTransferWithDocument() {
+        return addCompleteTransferWithDocuments(List.of(
+            EhrExtractStatus.GpcDocument.builder().documentId(DOCUMENT_ID).build()
+        ));
+    }
 
-    public EhrExtractStatus addCompleteTransferWithDocuments() {
+    private @NotNull EhrExtractStatus addCompleteTransferWithDocuments(List<EhrExtractStatus.GpcDocument> documents) {
         String ehrMessageRef = generateRandomUppercaseUUID();
 
         EhrExtractStatus extractStatus = EhrExtractStatus.builder()
@@ -423,9 +384,7 @@ public class EhrExtractStatusServiceTest {
                         .build())
                 .ehrRequest(buildEhrRequest())
                 .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
-                        .documents(List.of(
-                            EhrExtractStatus.GpcDocument.builder().documentId(DOCUMENT_ID).build()
-                        ))
+                        .documents(documents)
                         .build())
                 .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
                         .accessedAt(FIVE_DAYS_AGO)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -173,7 +173,8 @@ public class EhrExtractStatusService {
             DocumentTaskDefinition documentTaskDefinition,
             String storagePath,
             int base64ContentLength,
-            String errorMessage
+            String errorMessage,
+            String filename
     ) {
         Query query = new Query();
         query.addCriteria(Criteria
@@ -189,6 +190,7 @@ public class EhrExtractStatusService {
         update.set(DOCUMENT_MESSAGE_ID_PATH, documentTaskDefinition.getMessageId());
         update.set(DOCUMENT_BASE64_CONTENT_LENGTH, base64ContentLength);
         update.set(GPC_DOCUMENTS + ARRAY_REFERENCE + "gpConnectErrorMessage", errorMessage);
+        update.set(GPC_DOCUMENTS + ARRAY_REFERENCE + "fileName", filename);
         FindAndModifyOptions returningUpdatedRecordOption = getReturningUpdatedRecordOption();
 
         EhrExtractStatus ehrExtractStatus = mongoTemplate.findAndModify(query, update, returningUpdatedRecordOption,

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
@@ -46,7 +46,8 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
             taskDefinition.getConversationId()
         ));
 
-        var storagePath = buildAbsentAttachmentFileName(taskDefinition.getDocumentId());
+        final var storagePath = buildAbsentAttachmentFileName(taskDefinition.getDocumentId());
+        final var fileName = buildAbsentAttachmentFileName(taskDefinition.getDocumentId());
 
         var mhsOutboundRequestData = documentToMHSTranslator.translateFileContentToMhsOutboundRequestData(taskDefinition, fileContent);
 
@@ -56,7 +57,7 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
         storageConnectorService.uploadFile(storageDataWrapperWithMhsOutboundRequest, storagePath);
 
         return ehrExtractStatusService.updateEhrExtractStatusAccessDocument(
-            taskDefinition, storagePath, fileContent.length(), getTitle(taskDefinition)
+            taskDefinition, storagePath, fileContent.length(), getTitle(taskDefinition), fileName
         );
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
@@ -15,6 +15,7 @@ import uk.nhs.adaptors.gp2gp.common.task.TaskExecutor;
 import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusService;
 import uk.nhs.adaptors.gp2gp.ehr.GetAbsentAttachmentTaskExecutor;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+import uk.nhs.adaptors.gp2gp.ehr.utils.DocumentReferenceUtils;
 import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectException;
 
 @Slf4j
@@ -74,8 +75,9 @@ public class GetGpcDocumentTaskExecutor implements TaskExecutor<GetGpcDocumentTa
 
         storageConnectorService.uploadFile(storageDataWrapperWithMhsOutboundRequest, storagePath);
 
+        final var filename = DocumentReferenceUtils.buildPresentAttachmentFileName(taskDefinition.getDocumentId(), binary.getContentType());
         return ehrExtractStatusService.updateEhrExtractStatusAccessDocument(
-            taskDefinition, storagePath, contentAsBase64.length(), null);
+            taskDefinition, storagePath, contentAsBase64.length(), null, filename);
     }
 
     private StorageDataWrapper getStorageDataWrapper(


### PR DESCRIPTION
If the attachment ended up being absent after being fetched, we'd like to give it a new filename prefixed with 'AbsentAttachment'.

This prefix is part of the GP2GP spec for absent attachments

## What

Please include a summary of the changes and the related issue

## Why

Please include details of the reasoning for these changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
