### PR TITLE
Add scenario for '3 Attachments with 2 Absent' to wiremock

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -198,7 +199,7 @@ public class EhrExtractStatusServiceTest {
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_Expect_DocumentRecordUpdated() {
         when(timestampService.now()).thenReturn(NOW);
-        var ehrStatus = addCompleteTransferWithDocuments();
+        var ehrStatus = addCompleteTransferWithDocument();
 
         updateEhrExtractStatusAccessDocument(ehrStatus.getConversationId(), DOCUMENT_ID);
 
@@ -210,7 +211,8 @@ public class EhrExtractStatusServiceTest {
             () -> assertThat(actual.getObjectName()).isEqualTo("this is a storage path.path"),
             () -> assertThat(actual.getMessageId()).isEqualTo("988290"),
             () -> assertThat(actual.getContentLength()).isEqualTo(1),
-            () -> assertThat(actual.getGpConnectErrorMessage()).isEqualTo("This is a fantastic error message")
+            () -> assertThat(actual.getGpConnectErrorMessage()).isEqualTo("This is a fantastic error message"),
+            () -> assertThat(actual.getFileName()).isEqualTo("NewUpdatedFileName.txt")
         );
     }
 
@@ -224,13 +226,14 @@ public class EhrExtractStatusServiceTest {
                 .build(),
             "this is a storage path.path",
             1,
-            "This is a fantastic error message"
+            "This is a fantastic error message",
+            "NewUpdatedFileName.txt"
         );
     }
 
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_With_InvalidConversationId_Expect_ThrowsException() {
-        addCompleteTransferWithDocuments();
+        addCompleteTransferWithDocument();
 
         assertThrows(
             EhrExtractException.class,
@@ -240,7 +243,7 @@ public class EhrExtractStatusServiceTest {
 
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_With_InvalidDocumentId_Expect_ThrowsException() {
-        final var ehrStatus = addCompleteTransferWithDocuments();
+        final var ehrStatus = addCompleteTransferWithDocument();
 
         assertThrows(
             EhrExtractException.class,
@@ -252,7 +255,7 @@ public class EhrExtractStatusServiceTest {
     @Test
     public void When_UpdateEhrExtractStatusAccessDocument_Expect_ReturnsUpdatedEhrStatusRecord() {
         when(timestampService.now()).thenReturn(NOW);
-        var ehrStatus = addCompleteTransferWithDocuments();
+        var ehrStatus = addCompleteTransferWithDocument();
 
         final var returnedRecord = updateEhrExtractStatusAccessDocument(ehrStatus.getConversationId(), DOCUMENT_ID);
 
@@ -400,59 +403,17 @@ public class EhrExtractStatusServiceTest {
         ehrExtractStatusRepository.save(extractStatus);
     }
 
-    public EhrExtractStatus addCompleteTransfer() {
-        String ehrMessageRef = generateRandomUppercaseUUID();
-
-        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
-            .ackHistory(EhrExtractStatus.AckHistory.builder()
-                .acks(List.of(
-                    EhrExtractStatus.EhrReceivedAcknowledgement.builder()
-                        .rootId(generateRandomUppercaseUUID())
-                        .received(FIVE_DAYS_AGO)
-                        .conversationClosed(FIVE_DAYS_AGO)
-                        .messageRef(ehrMessageRef)
-                        .build()))
-                .build())
-            .ackPending(EhrExtractStatus.AckPending.builder()
-                .messageId(generateRandomUppercaseUUID())
-                .taskId(generateRandomUppercaseUUID())
-                .typeCode(ACK_TYPE)
-                .updatedAt(FIVE_DAYS_AGO.toString())
-                .build())
-            .ackToRequester(buildPositiveAckToRequester())
-            .conversationId(generateRandomUppercaseUUID())
-            .created(FIVE_DAYS_AGO)
-            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
-                .sentAt(FIVE_DAYS_AGO)
-                .build())
-            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
-                .sentAt(FIVE_DAYS_AGO)
-                .taskId(generateRandomUppercaseUUID())
-                .build())
-            .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder()
-                .conversationClosed(FIVE_DAYS_AGO)
-                .messageRef(ehrMessageRef)
-                .received(FIVE_DAYS_AGO)
-                .rootId(generateRandomUppercaseUUID())
-                .build())
-            .ehrRequest(buildEhrRequest())
-            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
-                .documents(new ArrayList<>())
-                .build())
-            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
-                .accessedAt(FIVE_DAYS_AGO)
-                .objectName(generateRandomUppercaseUUID() + ".json")
-                .taskId(generateRandomUppercaseUUID())
-                .build())
-            .messageTimestamp(FIVE_DAYS_AGO)
-            .updatedAt(FIVE_DAYS_AGO)
-            .build();
-
-        return ehrExtractStatusRepository.save(extractStatus);
+    private EhrExtractStatus addCompleteTransfer() {
+        return addCompleteTransferWithDocuments(List.of());
     }
 
+    private EhrExtractStatus addCompleteTransferWithDocument() {
+        return addCompleteTransferWithDocuments(List.of(
+            EhrExtractStatus.GpcDocument.builder().documentId(DOCUMENT_ID).build()
+        ));
+    }
 
-    public EhrExtractStatus addCompleteTransferWithDocuments() {
+    private @NotNull EhrExtractStatus addCompleteTransferWithDocuments(List<EhrExtractStatus.GpcDocument> documents) {
         String ehrMessageRef = generateRandomUppercaseUUID();
 
         EhrExtractStatus extractStatus = EhrExtractStatus.builder()
@@ -489,9 +450,7 @@ public class EhrExtractStatusServiceTest {
                         .build())
                 .ehrRequest(buildEhrRequest())
                 .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
-                        .documents(List.of(
-                            EhrExtractStatus.GpcDocument.builder().documentId(DOCUMENT_ID).build()
-                        ))
+                        .documents(documents)
                         .build())
                 .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
                         .accessedAt(FIVE_DAYS_AGO)

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -50,6 +50,7 @@ public class EhrExtractStatusServiceTest {
 
     public static final Instant NOW = Instant.now();
     private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
+    private static final int DEFAULT_CONTENT_LENGTH = 244;
 
     @Autowired
     private EhrExtractStatusService ehrExtractStatusService;
@@ -65,6 +66,7 @@ public class EhrExtractStatusServiceTest {
         ehrExtractStatusRepository.deleteAll();
     }
 
+    @SuppressWarnings("checkstyle:MagicNumber")
     @Test
     public void When_FetchDocumentObjectNameAndSize_With_OneMissingAttachment_Expect_Returned() {
         var inProgressConversationId = generateRandomUppercaseUUID();
@@ -74,7 +76,7 @@ public class EhrExtractStatusServiceTest {
         EhrExtractStatus.GpcDocument document = EhrExtractStatus.GpcDocument.builder()
                         .fileName("AbsentAttachment4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60.rtx")
                         .documentId("4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60")
-                        .contentLength(244)
+                        .contentLength(DEFAULT_CONTENT_LENGTH)
                         .gpConnectErrorMessage("404 Not Found")
                         .contentType("application/msword")
                         .build();
@@ -86,15 +88,18 @@ public class EhrExtractStatusServiceTest {
 
         Map<String, String> expectedResult = new HashMap<>();
 
-        expectedResult.put("FILENAME_PLACEHOLDER_ID=4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60", "AbsentAttachment4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60.rtx");
+        expectedResult.put("FILENAME_PLACEHOLDER_ID=4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60",
+                "AbsentAttachment4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60.rtx");
         expectedResult.put("LENGTH_PLACEHOLDER_ID=4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60", "244");
-        expectedResult.put("ERROR_MESSAGE_PLACEHOLDER_ID=4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60", "Absent Attachment: 404 Not Found");
+        expectedResult.put("ERROR_MESSAGE_PLACEHOLDER_ID=4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60",
+                "Absent Attachment: 404 Not Found");
         expectedResult.put("CONTENT_TYPE_PLACEHOLDER_ID=4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60", "text/plain");
 
         assertThat(results.size()).isEqualTo(4);
         assertThat(results).isEqualTo(expectedResult);
     }
 
+    @SuppressWarnings("checkstyle:MagicNumber")
     @Test
     public void When_FetchDocumentObjectNameAndSize_With_OnePresentAttachment_Expect_Returned() {
         var inProgressConversationId = generateRandomUppercaseUUID();
@@ -104,7 +109,7 @@ public class EhrExtractStatusServiceTest {
         EhrExtractStatus.GpcDocument document = EhrExtractStatus.GpcDocument.builder()
                 .fileName("4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60.rtx")
                 .documentId("4E0C8345-A9AB-48EA-8882-DC9E9F3F5F60")
-                .contentLength(244)
+                .contentLength(DEFAULT_CONTENT_LENGTH)
                 .gpConnectErrorMessage(null)
                 .contentType("application/msword")
                 .build();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr;
 import static java.lang.String.format;
 
 import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.springframework.util.CollectionUtils.newHashMap;
 
 import java.time.Instant;
 import java.util.List;
@@ -108,6 +109,9 @@ public class EhrExtractStatusService {
     private static final String ERROR_MESSAGE_PATH = ERROR + DOT + MESSAGE;
     private static final String ERROR_TASK_TYPE_PATH = ERROR + DOT + TASK_TYPE;
     private static final String LENGTH_PLACEHOLDER = "LENGTH_PLACEHOLDER_ID=";
+    private static final String ERROR_MESSAGE_PLACEHOLDER = "ERROR_MESSAGE_PLACEHOLDER_ID=";
+    private static final String CONTENT_TYPE_PLACEHOLDER = "CONTENT_TYPE_PLACEHOLDER_ID=";
+    private static final String FILENAME_TYPE_PLACEHOLDER = "FILENAME_PLACEHOLDER_ID=";
     private static final String ACKS_SET = ACK_HISTORY + DOT + ACKS;
 
     private final MongoTemplate mongoTemplate;
@@ -138,10 +142,27 @@ public class EhrExtractStatusService {
         if (ehrExtractStatusSearch.isPresent()) {
             var ehrExtractStatus = ehrExtractStatusSearch.get();
             var ehrDocuments = ehrExtractStatus.getGpcAccessDocument().getDocuments();
-            return ehrDocuments.stream()
-                .collect(Collectors.toMap(
-                    (document) -> LENGTH_PLACEHOLDER + document.getDocumentId(),
-                    (document) -> document.getContentLength() + ""));
+
+            Map<String, String> replacementMap = newHashMap(ehrDocuments.size());
+
+            for(var document:ehrDocuments){
+                String error = document.getGpConnectErrorMessage() == null ? "" :
+                        "Absent Attachment: " + document.getGpConnectErrorMessage();
+
+                replacementMap.put(ERROR_MESSAGE_PLACEHOLDER + document.getDocumentId(),
+                        error);
+                replacementMap.put(LENGTH_PLACEHOLDER + document.getDocumentId(),
+                        String.valueOf(document.getContentLength()));
+
+                if(document.getGpConnectErrorMessage() != null){
+                    replacementMap.put(CONTENT_TYPE_PLACEHOLDER + document.getDocumentId(), "text/plain");
+                }else{
+                    replacementMap.put(CONTENT_TYPE_PLACEHOLDER + document.getDocumentId(), document.getContentType());
+                }
+                replacementMap.put(FILENAME_TYPE_PLACEHOLDER + document.getDocumentId(), document.getFileName());
+            }
+
+            return replacementMap;
         }
         return null;
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -9,7 +9,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
@@ -145,18 +144,18 @@ public class EhrExtractStatusService {
 
             Map<String, String> replacementMap = newHashMap(ehrDocuments.size());
 
-            for(var document:ehrDocuments){
-                String error = document.getGpConnectErrorMessage() == null ? "" :
-                        "Absent Attachment: " + document.getGpConnectErrorMessage();
+            for (var document:ehrDocuments) {
+                String error = document.getGpConnectErrorMessage() == null ? ""
+                        : "Absent Attachment: " + document.getGpConnectErrorMessage();
 
                 replacementMap.put(ERROR_MESSAGE_PLACEHOLDER + document.getDocumentId(),
                         error);
                 replacementMap.put(LENGTH_PLACEHOLDER + document.getDocumentId(),
                         String.valueOf(document.getContentLength()));
 
-                if(document.getGpConnectErrorMessage() != null){
+                if (document.getGpConnectErrorMessage() != null) {
                     replacementMap.put(CONTENT_TYPE_PLACEHOLDER + document.getDocumentId(), "text/plain");
-                }else{
+                } else {
                     replacementMap.put(CONTENT_TYPE_PLACEHOLDER + document.getDocumentId(), document.getContentType());
                 }
                 replacementMap.put(FILENAME_TYPE_PLACEHOLDER + document.getDocumentId(), document.getFileName());

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -193,7 +193,8 @@ public class EhrExtractStatusService {
             DocumentTaskDefinition documentTaskDefinition,
             String storagePath,
             int base64ContentLength,
-            String errorMessage
+            String errorMessage,
+            String filename
     ) {
         Query query = new Query();
         query.addCriteria(Criteria
@@ -209,6 +210,7 @@ public class EhrExtractStatusService {
         update.set(DOCUMENT_MESSAGE_ID_PATH, documentTaskDefinition.getMessageId());
         update.set(DOCUMENT_BASE64_CONTENT_LENGTH, base64ContentLength);
         update.set(GPC_DOCUMENTS + ARRAY_REFERENCE + "gpConnectErrorMessage", errorMessage);
+        update.set(GPC_DOCUMENTS + ARRAY_REFERENCE + "fileName", filename);
         FindAndModifyOptions returningUpdatedRecordOption = getReturningUpdatedRecordOption();
 
         EhrExtractStatus ehrExtractStatus = mongoTemplate.findAndModify(query, update, returningUpdatedRecordOption,

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
@@ -46,7 +46,8 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
             taskDefinition.getConversationId()
         ));
 
-        var storagePath = buildAbsentAttachmentFileName(taskDefinition.getDocumentId());
+        final var storagePath = buildAbsentAttachmentFileName(taskDefinition.getDocumentId());
+        final var fileName = buildAbsentAttachmentFileName(taskDefinition.getDocumentId());
 
         var mhsOutboundRequestData = documentToMHSTranslator.translateFileContentToMhsOutboundRequestData(taskDefinition, fileContent);
 
@@ -56,7 +57,7 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
         storageConnectorService.uploadFile(storageDataWrapperWithMhsOutboundRequest, storagePath);
 
         return ehrExtractStatusService.updateEhrExtractStatusAccessDocument(
-            taskDefinition, storagePath, fileContent.length(), getTitle(taskDefinition)
+            taskDefinition, storagePath, fileContent.length(), getTitle(taskDefinition), fileName
         );
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
@@ -15,6 +15,7 @@ import uk.nhs.adaptors.gp2gp.common.task.TaskExecutor;
 import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusService;
 import uk.nhs.adaptors.gp2gp.ehr.GetAbsentAttachmentTaskExecutor;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+import uk.nhs.adaptors.gp2gp.ehr.utils.DocumentReferenceUtils;
 import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectException;
 
 @Slf4j
@@ -74,8 +75,9 @@ public class GetGpcDocumentTaskExecutor implements TaskExecutor<GetGpcDocumentTa
 
         storageConnectorService.uploadFile(storageDataWrapperWithMhsOutboundRequest, storagePath);
 
+        final var filename = DocumentReferenceUtils.buildPresentAttachmentFileName(taskDefinition.getDocumentId(), binary.getContentType());
         return ehrExtractStatusService.updateEhrExtractStatusAccessDocument(
-            taskDefinition, storagePath, contentAsBase64.length(), null);
+            taskDefinition, storagePath, contentAsBase64.length(), null, filename);
     }
 
     private StorageDataWrapper getStorageDataWrapper(

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-1.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-1.xml
@@ -1,7 +1,7 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Type: Referral Letter (21-Sep-2020) Author Org: Organisation name Custodian Org: Organisation name Description: for 2 week rule referral - skin Absent Attachment: some title Setting: Practice Setting Text</text>
+        <text>Type: Referral Letter (21-Sep-2020) Author Org: Organisation name Custodian Org: Organisation name Description: for 2 week rule referral - skin ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}Setting: Practice Setting Text</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921" />
         <Participant typeCode="PRF" contextControlCode="OP">
@@ -13,7 +13,7 @@
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/plain">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-1.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-1.xml
@@ -14,7 +14,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-10.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-10.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-10.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-10.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Absent Attachment: some title</text>
+        <text>${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/plain">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-11.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-11.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-11.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-11.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text></text>
+        <text>${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-12.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-12.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-12.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-12.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text></text>
+        <text>${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/plain">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-2.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-2.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-2.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-2.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Type: Referral Letter (21-Sep-2020)</text>
+        <text>Type: Referral Letter (21-Sep-2020) ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-3.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-3.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Type: Referral letter</text>
+        <text>Type: Referral letter ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-3.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-3.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-4.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-4.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-4.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-4.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text></text>
+        <text>${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-5.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-5.xml
@@ -14,7 +14,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-5.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-5.xml
@@ -1,7 +1,7 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Author Org: Organisation name</text>
+        <text>Author Org: Organisation name ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <Participant typeCode="PRF" contextControlCode="OP">
@@ -13,7 +13,7 @@
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-6.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-6.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-6.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-6.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Custodian Org: Organisation name</text>
+        <text>Custodian Org: Organisation name ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-7.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-7.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-7.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-7.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Description: for 2 week rule referral - skin</text>
+        <text>Description: for 2 week rule referral - skin ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-8.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-8.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-8.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-8.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Setting: Practice Setting Text</text>
+        <text>${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}Setting: Practice Setting Text</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-9.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-9.xml
@@ -9,7 +9,7 @@
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
                 <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
-                    <reference value="file://localhost/394559384658936.rtx"/>
+                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                 </text>
             </referredToExternalDocument>
         </reference>

--- a/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-9.xml
+++ b/service/src/test/resources/ehr/mapper/documentreference/expected-output-narrative-statement-9.xml
@@ -1,14 +1,14 @@
 <component typeCode="COMP" >
     <NarrativeStatement classCode="OBS" moodCode="EVN">
         <id root="394559384658936" />
-        <text>Setting: Practice Setting Display</text>
+        <text>${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}Setting: Practice Setting Display</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="20200921141759" />
         <reference typeCode="REFR">
             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                 <id root="394559384658936"/>
                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                <text mediaType="text/richtext">
+                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
                     <reference value="file://localhost/394559384658936.rtx"/>
                 </text>
             </referredToExternalDocument>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
@@ -261,8 +261,7 @@
             <component typeCode="COMP">
                 <NarrativeStatement classCode="OBS" moodCode="EVN">
                     <id root="394559384658936"/>
-                    <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin Absent Attachment: some title
-                        Setting: Practice Setting Text
+                    <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}Setting: Practice Setting Text
                     </text>
                     <statusCode code="COMPLETE"/>
                     <availabilityTime value="20200921"/>
@@ -275,8 +274,8 @@
                         <referredToExternalDocument classCode="DOC" moodCode="EVN">
                             <id root="394559384658936"/>
                             <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                            <text mediaType="text/plain">
-                                <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                            <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
+                                <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                             </text>
                         </referredToExternalDocument>
                     </reference>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-14-category-codes.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-14-category-codes.xml
@@ -50,8 +50,7 @@
                 <component typeCode="COMP">
                     <NarrativeStatement classCode="OBS" moodCode="EVN">
                         <id root="394559384658936"/>
-                        <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin Absent Attachment: some title
-                            Setting: Practice Setting Text
+                        <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}Setting: Practice Setting Text
                         </text>
                         <statusCode code="COMPLETE"/>
                         <availabilityTime value="20200921"/>
@@ -64,8 +63,8 @@
                             <referredToExternalDocument classCode="DOC" moodCode="EVN">
                                 <id root="394559384658936"/>
                                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Other digital signal"/>
-                                <text mediaType="text/plain">
-                                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
+                                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                                 </text>
                             </referredToExternalDocument>
                         </reference>

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-16-topic-codes.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-16-topic-codes.xml
@@ -70,10 +70,7 @@
                 <component typeCode="COMP">
                     <NarrativeStatement classCode="OBS" moodCode="EVN">
                         <id root="394559384658936"/>
-                        <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin Absent
-                            Attachment: some title
-                            Setting: Practice Setting Text
-                        </text>
+                        <text>Type: Referral Letter (21-Sep-2020) Description: for 2 week rule referral - skin ${ERROR_MESSAGE_PLACEHOLDER_ID=394559384658936}Setting: Practice Setting Text</text>
                         <statusCode code="COMPLETE"/>
                         <availabilityTime value="20200921"/>
                         <Participant typeCode="PRF" contextControlCode="OP">
@@ -86,8 +83,8 @@
                                 <id root="394559384658936"/>
                                 <code code="37251000000104" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
                                       displayName="Other digital signal"/>
-                                <text mediaType="text/plain">
-                                    <reference value="file://localhost/AbsentAttachment394559384658936.txt"/>
+                                <text mediaType="${CONTENT_TYPE_PLACEHOLDER_ID=394559384658936}">
+                                    <reference value="file://localhost/${FILENAME_PLACEHOLDER_ID=394559384658936}"/>
                                 </text>
                             </referredToExternalDocument>
                         </reference>

--- a/wiremock/README.md
+++ b/wiremock/README.md
@@ -28,7 +28,7 @@ Each scenario below can be retrieved by requesting the associated NHS Number spe
 
 - [No Documents](stubs/__files/correctPatientNoDocsStructuredRecordResponse.json) 9690937294
 - [1 Absent Attachment](stubs/__files/correctPatientStructuredRecordResponseAbsentAttachment.json) 9690937286
-- [3 Absent Attachments](stubs/__files/correctPatientStructuredRecordResponse3AbsentAttachmentDocuments.json) 9690937419
+- [3 Attachments with 2 Absent](stubs/__files/correctPatientStructuredRecordResponse3AttachmentsWith2Absent.json) 9690937419
 - [With three 10Kb .doc files](stubs/__files/correctPatientStructuredRecordResponse3NormalDocuments.json) 9690937420
 - [With one 20Kb document](stubs/__files/correctPatientStructuredRecordResponseForLargeDocs.json) 9690937819
 - [With one 40Kb document](stubs/__files/correctPatientStructuredRecordResponseForLargeDocs2.json) 9690937841
@@ -78,6 +78,12 @@ To change the patient record returned to be [Large Patient Record](stubs/__files
 
 ```shell
 curl --request PUT --data '{"state": "Large Patient Record"}' http://localhost:8110/__admin/scenarios/migrateStructuredRecord/state
+```
+
+To change the patient record returned to be [3 Attachments with 2 Absent](stubs/__files/correctPatientStructuredRecordResponse3AttachmentsWith2Absent.json):
+
+```shell
+curl --request PUT --data '{"state": "3 Attachments with 2 Absent"}' http://localhost:8110/__admin/scenarios/migrateStructuredRecord/state
 ```
 
 To change the patient record returned to be NOT FOUND:

--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponse3AttachmentsWith2Absent.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponse3AttachmentsWith2Absent.json
@@ -1,0 +1,16629 @@
+{
+    "resourceType": "Bundle",
+    "id": "6a92c467-ff0c-4089-a5d1-285d20cb9f92",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+        ]
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "2",
+                "meta": {
+                    "versionId": "1521806400000",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-RegistrationDetails-1",
+                        "extension": [
+                            {
+                                "url": "registrationPeriod",
+                                "valuePeriod": {
+                                    "start": "1962-07-13T00:00:00+01:00"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSCommunication-1",
+                        "extension": [
+                            {
+                                "url": "language",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-HumanLanguage-1",
+                                            "code": "en",
+                                            "display": "English"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "url": "preferred",
+                                "valueBoolean": false
+                            },
+                            {
+                                "url": "modeOfCommunication",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-LanguageAbilityMode-1",
+                                            "code": "RWR",
+                                            "display": "Received written"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "url": "communicationProficiency",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-LanguageAbilityProficiency-1",
+                                            "code": "E",
+                                            "display": "Excellent"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "url": "interpreterRequired",
+                                "valueBoolean": false
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSNumberVerificationStatus-1",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-NHSNumberVerificationStatus-1",
+                                            "code": "01",
+                                            "display": "Number present and verified"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "{{jsonPath request.body '$.parameter[0].valueIdentifier.value'}}"
+                    }
+                ],
+                "active": true,
+                {{^patient}}
+                "name":
+                [
+                    {
+                        "use": "official",
+                        "text": "Horace SKELLY",
+                        "family": "SKELLY",
+                        "given": [
+                            "Horace"
+                        ],
+                        "prefix": [
+                            "MR"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1925-04-21",
+                "address": [
+                    {
+                        "use": "home",
+                        "type": "physical",
+                        "line": [
+                            "3 BOWESFIELD CRESCENT"
+                        ],
+                        "city": "STOCKTON-ON-TEES",
+                        "postalCode": "TS18 3BL"
+                    }
+                ],
+                {{/patient}}
+                {{#patient}}
+                "name": [
+                    {
+                        "use": "official",
+                        "text": "{{patient.name.0.given.0}} {{patient.name.0.family}}",
+                        "family": "{{patient.name.0.family}}",
+                        "given": [
+                            "{{patient.name.0.given.0}}"
+                        ],
+                        "prefix": [
+                            "{{patient.name.0.prefix.0}}"
+                        ]
+                    }
+                ],
+                "gender": "{{ patient.gender }}",
+                "birthDate": "{{ patient.birthDate }}",
+                "address": [
+                    {
+                        "use": "home",
+                        "type": "physical",
+                        "line": [
+                            "{{ patient.address.0.line.0 }}",
+                            "{{ patient.address.0.line.1 }}"
+                        ],
+                        "postalCode": "{{ patient.address.0.postalCode }}"
+                    }
+                ],
+                {{/patient}}
+                "contact": [
+                    {
+                        "relationship": [
+                            {
+                                "text": "Emergency contact"
+                            },
+                            {
+                                "text": "Next of kin"
+                            },
+                            {
+                                "text": "Daughter"
+                            }
+                        ],
+                        "name": {
+                            "use": "official",
+                            "text": "JACKSON Jane (Miss)",
+                            "family": "Jackson",
+                            "given": [
+                                "Jane"
+                            ],
+                            "prefix": [
+                                "Miss"
+                            ]
+                        },
+                        "telecom": [
+                            {
+                                "system": "phone",
+                                "value": "07777123123",
+                                "use": "mobile"
+                            }
+                        ],
+                        "address": {
+                            "use": "home",
+                            "type": "physical",
+                            "line": [
+                                "Trevelyan Square",
+                                "Boar Ln"
+                            ],
+                            "postalCode": "LS1 6AE"
+                        },
+                        "gender": "female"
+                    }
+                ],
+                "generalPractitioner": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "managingOrganization": {
+                    "reference": "Organization/7"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "1",
+                "meta": {
+                    "versionId": "1469444400000",
+                    "lastUpdated": "2016-07-25T12:00:00.000+01:00",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSCommunication-1",
+                        "extension": [
+                            {
+                                "url": "language",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-HumanLanguage-1",
+                                            "code": "de",
+                                            "display": "German"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSCommunication-1",
+                        "extension": [
+                            {
+                                "url": "language",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-HumanLanguage-1",
+                                            "code": "en",
+                                            "display": "English"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                        "value": "G13579135"
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "usual",
+                        "family": "Gilbert",
+                        "given": [
+                            "Nichole"
+                        ],
+                        "prefix": [
+                            "Miss"
+                        ]
+                    }
+                ],
+                "gender": "female"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "6c41ebfd-57c3-4162-9d7b-208c171a2fd7"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "7",
+                "meta": {
+                    "versionId": "1469444400000",
+                    "lastUpdated": "2016-07-25T12:00:00.000+01:00",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                        "value": "B82617"
+                    }
+                ],
+                "name": "COXWOLD SURGERY",
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "12345678",
+                        "use": "work"
+                    }
+                ],
+                "address": [
+                    {
+                        "use": "work",
+                        "line": [
+                            "NHS NPFIT Test Data Manager",
+                            "Princes Exchange"
+                        ],
+                        "city": "Leeds",
+                        "district": "West Yorkshire",
+                        "postalCode": "LS1 4HY"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "e0244de8-07ef-4274-9f7a-d7067bcc8d21",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-PractitionerRole-1"
+                    ]
+                },
+                "practitioner": {
+                    "reference": "Practitioner/6c41ebfd-57c3-4162-9d7b-208c171a2fd7"
+                },
+                "organization": {
+                    "reference": "Organization/db67f447-b30d-442a-8e31-6918d1367eeb"
+                },
+                "code": [
+                    {
+                        "coding": [
+                            {
+                                "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1",
+                                "code": "R0260",
+                                "display": "General Medical Practitioner"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Location",
+                "id": "17",
+                "meta": {
+                    "versionId": "636064088100870233",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Location-1"
+                    ]
+                },
+                "name": "The Trevelyan Practice",
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "03003035678",
+                        "use": "work"
+                    }
+                ],
+                "address": {
+                    "line": [
+                        "Trevelyan Square",
+                        "Boar Ln",
+                        "Leeds"
+                    ],
+                    "postalCode": "LS1 6AE"
+                },
+                "managingOrganization": {
+                    "reference": "Organization/db67f447-b30d-442a-8e31-6918d1367eeb"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "AllergyIntolerance",
+                "id": "29",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb496f15-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "verificationStatus": "unconfirmed",
+                "category": [
+                    "environment"
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "descriptionId",
+                                            "valueId": "148720012"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "89707004",
+                            "display": "Sesame oil (substance)"
+                        }
+                    ]
+                },
+                "patient": {
+                    "reference": "Patient/2"
+                },
+                "onsetDateTime": "1963-07-27T12:00:00+01:00",
+                "assertedDate": "1963-07-27T12:00:00+01:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "reaction": [
+                    {
+                        "manifestation": [
+                            {
+                                "coding": [
+                                    {
+                                        "extension": [
+                                            {
+                                                "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                                "extension": [
+                                                    {
+                                                        "url": "descriptionId",
+                                                        "valueId": "344917018"
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "system": "http://snomed.info/sct",
+                                        "code": "230145002",
+                                        "display": "Difficulty breathing"
+                                    }
+                                ]
+                            }
+                        ],
+                        "severity": "severe"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Allergies and adverse reactions",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "886921000000105",
+                            "display": "Allergies and adverse reactions"
+                        }
+                    ]
+                },
+                "subject": {
+                    "identifier": {
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "9729649766"
+                    }
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "AllergyIntolerance/29"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "contained": [
+                    {
+                        "resourceType": "AllergyIntolerance",
+                        "id": "28",
+                        "meta": {
+                            "profile": [
+                                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+                            ]
+                        },
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-AllergyIntoleranceEnd-1",
+                                "extension": [
+                                    {
+                                        "url": "endDate",
+                                        "valueDateTime": "2016-11-01T00:00:00+00:00"
+                                    },
+                                    {
+                                        "url": "reasonEnded",
+                                        "valueString": "Desensitised to Peanuts"
+                                    }
+                                ]
+                            }
+                        ],
+                        "identifier": [
+                            {
+                                "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                                "value": "bb496e52-bca8-11eb-b888-1002b58598b4"
+                            }
+                        ],
+                        "clinicalStatus": "resolved",
+                        "verificationStatus": "unconfirmed",
+                        "category": [
+                            "environment"
+                        ],
+                        "code": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                            "extension": [
+                                                {
+                                                    "url": "descriptionId",
+                                                    "valueId": "152306018"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "system": "http://snomed.info/sct",
+                                    "code": "91935009",
+                                    "display": "Allergy to peanuts"
+                                },
+                                {
+                                    "system": "http://read.info/ctv3",
+                                    "code": "Xa1no",
+                                    "display": "Peanut allergy",
+                                    "userSelected": true
+                                }
+                            ]
+                        },
+                        "patient": {
+                            "reference": "Patient/2"
+                        },
+                        "onsetDateTime": "1962-08-12T00:00:00+01:00",
+                        "assertedDate": "2016-11-01T00:00:00+00:00",
+                        "recorder": {
+                            "reference": "Practitioner/1"
+                        },
+                        "lastOccurrence": "2016-11-01T00:00:00+00:00",
+                        "reaction": [
+                            {
+                                "manifestation": [
+                                    {
+                                        "coding": [
+                                            {
+                                                "extension": [
+                                                    {
+                                                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                                        "extension": [
+                                                            {
+                                                                "url": "descriptionId",
+                                                                "valueId": "372285017"
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "system": "http://snomed.info/sct",
+                                                "code": "249519007",
+                                                "display": "Diarrhoea and vomiting"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "severity": "mild"
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Ended allergies",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1103671000000101",
+                            "display": "Ended allergies"
+                        }
+                    ]
+                },
+                "subject": {
+                    "identifier": {
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "9729649766"
+                    }
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "#28"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Problems - linked problems not relating to the primary query",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/GPConnect-SecondaryListValues-1",
+                            "code": "problems-linked-problems-not-relating-to-the-primary-query",
+                            "display": "Problems - linked problems not relating to the primary query"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2020-12-01T00:00:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Condition/AllergiesProblem"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/MedicationProblem"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/ImmunisationsProblem"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/ReferralsProblem"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/UncategorisedDataProblem"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/InvestigationsProblem"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "AllergiesProblem",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "AllergyIntolerance/29"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "D06C0517-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "assertedDate": "2020-12-01T00:00:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-ClinicalSetting-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "http://snomed.info/sct",
+                                    "code": "1060971000000108",
+                                    "display": "General practice service"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-ListWarningCode-1",
+                        "valueCode": "confidential-items"
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Medications and medical devices",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "933361000000108",
+                            "display": "Medications and medical devices"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "identifier": {
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "9729649766"
+                    }
+                },
+                "date": "2021-05-24T16:57:55+01:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/codesystem-list-order.html",
+                            "code": "event-date",
+                            "display": "Sorted by Event Date"
+                        }
+                    ]
+                },
+                "note": [
+                    {
+                        "text": "Items excluded due to confidentiality and/or patient preferences."
+                    }
+                ],
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/9"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/10"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/11"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/12"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2018-08-17"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-MedicationStatementDosageLastChanged-1",
+                        "valueDateTime": "2018-08-17T00:00:00+01:00"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49b9f4-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "status": "active",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "effectivePeriod": {
+                    "start": "2017-11-10T00:00:00+00:00",
+                    "end": "2018-09-14T00:00:00+01:00"
+                },
+                "dateAsserted": "2017-11-10T00:00:00+00:00",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in the morning"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "20",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "9751511000001104",
+                            "display": "Sertraline 100mg tablets"
+                        },
+                        {
+                            "system": "https://fhir.hl7.org.uk/Id/multilex-drug-codes",
+                            "code": "06157009",
+                            "display": "Sertraline 100mg tablets",
+                            "userSelected": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "20",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valuePositiveInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valuePositiveInt": 11
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498c2a-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "active",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-10T00:00:00+00:00",
+                        "end": "2018-08-15T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "21",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498cbf-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-10T00:00:00+00:00",
+                        "end": "2017-12-08T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "22",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498d4e-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-12-08T00:00:00+00:00",
+                        "end": "2018-01-04T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "23",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498dd9-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-01-05T00:00:00+00:00",
+                        "end": "2018-02-01T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "24",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498e7f-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-02-02T00:00:00+00:00",
+                        "end": "2018-03-01T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "25",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498f0a-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-03-02T00:00:00+00:00",
+                        "end": "2018-03-29T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "26",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498f93-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-03-30T00:00:00+01:00",
+                        "end": "2018-04-26T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "27",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb498ff0-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-04-27T00:00:00+01:00",
+                        "end": "2018-05-24T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "28",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499047-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-05-25T00:00:00+01:00",
+                        "end": "2018-06-21T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "29",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49909b-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-06-22T00:00:00+01:00",
+                        "end": "2018-07-19T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "30",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49910f-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-07-20T00:00:00+01:00",
+                        "end": "2018-08-16T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "31",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499162-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/20"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-3"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/20"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-10T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet once a day",
+                        "patientInstruction": "Take in morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-15T00:00:00+01:00",
+                        "end": "2018-09-13T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "9",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2018-08-29"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-MedicationStatementDosageLastChanged-1",
+                        "valueDateTime": "2018-08-29T00:00:00+01:00"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bd0d-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "status": "active",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "effectivePeriod": {
+                    "start": "2017-11-22T00:00:00+00:00",
+                    "end": "2018-09-26T00:00:00+01:00"
+                },
+                "dateAsserted": "2017-11-22T00:00:00+00:00",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "21",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "411533003",
+                            "display": "Metformin 2G Modified-Release tablets"
+                        },
+                        {
+                            "system": "https://fhir.hl7.org.uk/Id/multilex-drug-codes",
+                            "code": "16967001",
+                            "display": "Metformin 1g modified release tablets",
+                            "userSelected": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "32",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valuePositiveInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valuePositiveInt": 1
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4991b9-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "active",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-22T00:00:00+00:00",
+                        "end": "2018-12-27T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "33",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499212-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-22T00:00:00+00:00",
+                        "end": "2017-12-19T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "34",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499269-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-12-20T00:00:00+00:00",
+                        "end": "2018-01-16T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "35",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4992be-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-01-17T00:00:00+00:00",
+                        "end": "2018-02-13T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "36",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499314-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-02-14T00:00:00+00:00",
+                        "end": "2018-03-13T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "37",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4993a5-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-03-14T00:00:00+00:00",
+                        "end": "2018-04-10T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "38",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499400-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-04-11T00:00:00+01:00",
+                        "end": "2018-05-08T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "39",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499456-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-05-09T00:00:00+01:00",
+                        "end": "2018-06-05T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "40",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4994ac-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-06-06T00:00:00+01:00",
+                        "end": "2018-07-03T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "41",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499505-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-07-04T00:00:00+01:00",
+                        "end": "2018-07-31T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "42",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49955b-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-01T00:00:00+01:00",
+                        "end": "2018-08-28T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "43",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4995b0-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-29T00:00:00+01:00",
+                        "end": "2018-09-25T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "1043",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat-dispensing",
+                                    "display": "Repeat dispensing"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a2ee-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/32"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2a"
+                },
+                "status": "active",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/21"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "2 tablets a day",
+                        "patientInstruction": "With evening meal"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-09-25T00:00:00+01:00",
+                        "end": "2018-10-24T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "56"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "10",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2018-08-29"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-MedicationStatementDosageLastChanged-1",
+                        "valueDateTime": "2018-08-29T00:00:00+01:00"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bd70-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "status": "active",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "effectivePeriod": {
+                    "start": "2017-11-22T00:00:00+00:00",
+                    "end": "2018-09-26T00:00:00+01:00"
+                },
+                "dateAsserted": "2017-11-22T00:00:00+00:00",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "22",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "320030001",
+                            "display": "Atorvastaton 20mg tablets"
+                        },
+                        {
+                            "system": "https://fhir.hl7.org.uk/Id/multilex-drug-codes",
+                            "code": "10688002",
+                            "display": "Atorvastatin 20mg tablets",
+                            "userSelected": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "44",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valuePositiveInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valuePositiveInt": 11
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499607-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "active",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-22T00:00:00+00:00",
+                        "end": "2018-12-27T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "45",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49965c-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-22T00:00:00+00:00",
+                        "end": "2017-12-19T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "46",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4996b1-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-12-20T00:00:00+00:00",
+                        "end": "2018-01-16T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "47",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499705-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-01-17T00:00:00+00:00",
+                        "end": "2018-02-13T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "48",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49975a-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-02-14T00:00:00+00:00",
+                        "end": "2018-03-13T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "49",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4997ae-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-03-14T00:00:00+00:00",
+                        "end": "2018-04-10T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "50",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499801-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-04-11T00:00:00+01:00",
+                        "end": "2018-05-08T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "51",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499855-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-05-09T00:00:00+01:00",
+                        "end": "2018-06-05T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "52",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4998a8-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-06-06T00:00:00+01:00",
+                        "end": "2018-07-03T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "53",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb4999c4-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-07-04T00:00:00+01:00",
+                        "end": "2018-07-31T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "54",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499a1f-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-01T00:00:00+01:00",
+                        "end": "2018-08-28T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "55",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499a74-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/44"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2b"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/22"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-29T00:00:00+01:00",
+                        "end": "2018-09-25T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "11",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2018-08-29"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-MedicationStatementDosageLastChanged-1",
+                        "valueDateTime": "2018-08-29T00:00:00+01:00"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bdce-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "status": "active",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "effectivePeriod": {
+                    "start": "2017-11-22T00:00:00+00:00",
+                    "end": "2018-09-26T00:00:00+01:00"
+                },
+                "dateAsserted": "2017-11-22T00:00:00+00:00",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "23",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "325242002",
+                            "display": "Gliclazide 80mg tables"
+                        },
+                        {
+                            "system": "https://fhir.hl7.org.uk/Id/multilex-drug-codes",
+                            "code": "03716001",
+                            "display": "Gliclazide 80mg tablets",
+                            "userSelected": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "56",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valuePositiveInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valuePositiveInt": 11
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499ac7-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "active",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-22T00:00:00+00:00",
+                        "end": "2018-12-27T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "57",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499b1d-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-11-22T00:00:00+00:00",
+                        "end": "2017-12-19T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "58",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499b72-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2017-12-20T00:00:00+00:00",
+                        "end": "2018-01-16T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "59",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499bc6-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-01-17T00:00:00+00:00",
+                        "end": "2018-02-13T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "60",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499c1a-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-02-14T00:00:00+00:00",
+                        "end": "2018-03-13T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "61",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499c6f-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-03-14T00:00:00+00:00",
+                        "end": "2018-04-10T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "62",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499cc1-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-04-11T00:00:00+01:00",
+                        "end": "2018-05-08T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "63",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499d14-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-05-09T00:00:00+01:00",
+                        "end": "2018-06-05T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "64",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499d67-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-06-06T00:00:00+01:00",
+                        "end": "2018-07-03T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "65",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499db9-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-07-04T00:00:00+01:00",
+                        "end": "2018-07-31T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "66",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499e0b-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-01T00:00:00+01:00",
+                        "end": "2018-08-28T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "67",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499e5d-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/56"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-2c"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/23"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2017-11-22T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "1 tablet a day",
+                        "patientInstruction": "Morning"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-29T00:00:00+01:00",
+                        "end": "2018-09-25T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "28"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "12",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2018-08-27"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-MedicationStatementDosageLastChanged-1",
+                        "valueDateTime": "2018-08-27T00:00:00+01:00"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49be29-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "status": "active",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "effectivePeriod": {
+                    "start": "2018-01-15T00:00:00+00:00",
+                    "end": "2018-12-14T00:00:00+00:00"
+                },
+                "dateAsserted": "2018-01-15T00:00:00+00:00",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "dosage": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/nocte"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "24",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "11933011000001106",
+                            "display": "Lantus 100units/ml solution for injections 3ml pre-filled solostar pen"
+                        },
+                        {
+                            "system": "https://fhir.hl7.org.uk/Id/multilex-drug-codes",
+                            "code": "15577001",
+                            "display": "Lantus 100units/ml solution for injection 3ml pre-filled SoloStar pen (Sanofi)",
+                            "userSelected": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "68",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+                        "extension": [
+                            {
+                                "url": "numberOfRepeatPrescriptionsAllowed",
+                                "valuePositiveInt": 12
+                            },
+                            {
+                                "url": "numberOfRepeatPrescriptionsIssued",
+                                "valuePositiveInt": 9
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499f77-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "active",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-01-15T00:00:00+00:00",
+                        "end": "2018-12-17T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "69",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb499fd5-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-01-15T00:00:00+00:00",
+                        "end": "2018-02-11T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "70",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a044-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-02-12T00:00:00+00:00",
+                        "end": "2018-03-11T00:00:00+00:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "71",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a09b-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-03-12T00:00:00+00:00",
+                        "end": "2018-04-08T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "72",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a0f1-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-04-09T00:00:00+01:00",
+                        "end": "2018-05-06T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "73",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a144-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-05-07T00:00:00+01:00",
+                        "end": "2018-06-03T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "74",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a199-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-06-04T00:00:00+01:00",
+                        "end": "2018-07-01T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "75",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a1ee-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-07-02T00:00:00+01:00",
+                        "end": "2018-07-29T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "76",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a243-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-07-30T00:00:00+01:00",
+                        "end": "2018-08-26T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "77",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "repeat",
+                                    "display": "Repeat"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49a298-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/68"
+                    }
+                ],
+                "groupIdentifier": {
+                    "value": "M-1"
+                },
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/24"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2018-01-15T00:00:00+00:00",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "dosageInstruction": [
+                    {
+                        "text": "As directed",
+                        "patientInstruction": "Night/Nocte"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2018-08-27T00:00:00+01:00",
+                        "end": "2018-09-24T00:00:00+01:00"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "5 pens"
+                            }
+                        ]
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    },
+                    "performer": {
+                        "reference": "Organization/1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "MedicationProblem",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/20"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "D06C0517-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "assertedDate": "2020-12-01T00:00:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "List of consultations",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1149501000000101",
+                            "display": "List of consultations"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2019-03-28T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Encounter/Encounter1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Encounter/Encounter2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Encounter/Encounter3"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "Encounter1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "b6dfd800-7e80-41ba-9f91-0a5d981271f2"
+                    }
+                ],
+                "status": "finished",
+                "type": [
+                    {
+                        "text": "Surgery Consultation"
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "participant": [
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "PPRF",
+                                        "display": "primary performer"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "REC",
+                                        "display": "recorder"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1"
+                        }
+                    }
+                ],
+                "period": {
+                    "start": "2019-03-28T10:30:00+00:00",
+                    "end": "2019-03-28T10:38:00+00:00"
+                },
+                "length": {
+                    "value": 8,
+                    "unit": "m",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "min"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Surgery Consultation",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "325851000000107",
+                            "display": "Consultation"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic5"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-A-Anxiety-With-Depression"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Anxiety with Depression",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic1-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic1-Category-Examination"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic1-Category-Social"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic1-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic1-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic1-Category-Examination",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Examination",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Examination-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic1-Category-Social",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Social",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic1-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation1-Topic1-Category-Plan-Medication-Plan"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation1-Topic1-Category-Plan-Medication-Order"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Referral items are not supported by the provider system"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Plan-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-B-Swollen-Legs"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Swollen legs",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic2-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic2-Category-Examination"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic2-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic2-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-History-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic2-Category-Examination",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Examination",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-5"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic2-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "display": "Test request items are not supported by the provider system"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic3-flat-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic3-flat-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation1-Topic3-flat-Medication-Plan-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation1-Topic3-flat-Medication-Order-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic4",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-D-URTI"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Upper respiratory tract infection",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic4-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic4-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic4-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-D-URTI"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-5"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic4-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation1-Topic4-Category-Plan-Medication-Order-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation1-Topic4-Category-Plan-Medication-Plan-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic5",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Knee Pain",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic5-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic5-Category-Examination"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation1-Topic5-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic5-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-4"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic5-Category-Examination",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Examination",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-Examination-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation1-Topic5-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-03-28T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Referral items are not supported by the provider system"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic1-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "2eb8c7d2-db86-4381-a1cb-f98081bdd322"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Come for review. Overall doing better. Mood still low but improving. More good days than bad. Energy levels ok. Motivation improving. Support from neighbour visits daily"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic1-Category-History-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "00d91fe6-d6c7-48c9-a3df-2576a3028e9e"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "346979010"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Mixed anxiety and depressive disorder"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic1-Category-Examination-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "9057767b-bec8-4693-9966-aeb7180273de"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "MSE euthymic. Not anxious. No DSH/hallucinations/abnormal thoughts"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic1-Category-Social-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "7b3241ab-3bc9-468a-b859-e9c1e83cb733"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "397732011"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "266919005",
+                            "display": "Never smoked tobacco"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic1-Category-Social-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "f85ad281-0d1a-44e1-995f-5fd91806adb9"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2713011000000113"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "1082641000000106",
+                            "display": "Alcohol units consumed per week"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 0,
+                    "unit": "units/week"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic1-Category-Plan-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "da70bdad-4199-470a-a2a3-e2a874d51a96"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "1456478014"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Walking practice (regime/therapy)"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "308931006",
+                            "display": "Walking practice"
+                        }
+                    ]
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Advised re local walking group"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation1-Topic1-Category-Plan-Medication-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "a6ffc811-427a-445d-a14c-f5c4eaeea45d"
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/c260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-03-28",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-03-28",
+                        "end": "2019-04-25"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "capsule(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "c260b451-9821-42de-81f9-ba86dcea2c32",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "321987003",
+                            "display": "Citalopram 20mg tablets"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation1-Topic1-Category-Plan-Medication-Order",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "a8e2e70b-deae-4095-a357-948f20a2c24f"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation1-Topic1-Category-Plan-Medication-Plan"
+                    }
+                ],
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/c260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-03-28",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-03-28",
+                        "end": "2019-04-25"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "capsule(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "315873a1-90a3-4d67-bb77-f524597bb105"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "2 months - bilateral swollen lower legs"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-History-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "6a655e44-3a0c-4f54-ae6d-240ede80f38c"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2729461000000110"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Swollen leg"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "449614009",
+                            "display": "Swelling of lower limb"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-Examination-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "66b3ba3a-1b48-4862-8485-91935f83e379"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "3008650016"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "703421000",
+                            "display": "Temperature"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 36.7,
+                    "unit": "C",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "Cel"
+                },
+                "comment": "Patient looks flushed"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-Examination-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "0a297909-f2a2-4018-8ae6-28cab9e1cfa1"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2748921000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "1097811000000106",
+                            "display": "Arterial oxygen saturation breathing room air at rest"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 96,
+                    "unit": "%",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "%"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-Examination-Observation-3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "382e30ce-94dd-4c3b-b2b6-b383aa2ad871"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "143107019"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "86290005",
+                            "display": "Respiratory rate"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 16,
+                    "unit": "breaths per minute",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "{resps}/min"
+                },
+                "comment": "Chest clear"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-Examination-Observation-4",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "537a8de2-19ce-4f47-8db3-2c45e50f4b4e"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "406493011"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "271637005",
+                            "display": "Pulse irregularly irregular"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 70,
+                    "unit": "per minute",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "{beats}/min"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-Examination-Observation-5",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "04839d1d-1292-40e6-a0df-6217b447d325"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Swelling lower legs bilaterally. Mild pitting oedema. Heart sounds normal. No distress. Abdomen normal. No cervical lymphadenopathy. Throat normal. Ears normal"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-Plan-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "9a86a734-d738-4681-a008-d8881db2493d"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Advice to mobilise more. Review with results."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic2-Category-Plan-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "78049019"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "46825001",
+                            "display": "Electrocardiographic monitoring"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic3-flat-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "56d714ad-3fd3-4281-b1bb-c165352354cd"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2474699019"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "413153004",
+                            "display": "Blood pressure recorded by patient at home"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "average 150/90 last six weeks"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic3-flat-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "ae522c81-1b93-4d45-9c57-19249031350f"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdecsid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "254063019"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "163020007",
+                            "display": "O/E - blood pressure reading"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "component": [
+                    {
+                        "code": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                            "extension": [
+                                                {
+                                                    "url": "DescriptionID",
+                                                    "valueId": "254075012"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "system": "http://snomed.info/sct",
+                                    "code": "163030003",
+                                    "display": "O/E - Systolic BP reading"
+                                }
+                            ],
+                            "text": "O/E Systolic BP reading"
+                        },
+                        "valueQuantity": {
+                            "value": 130,
+                            "unit": "mm[Hg]"
+                        }
+                    },
+                    {
+                        "code": {
+                            "coding": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                            "extension": [
+                                                {
+                                                    "url": "DescriptionID",
+                                                    "valueId": "254076013"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "system": "http://snomed.info/sct",
+                                    "code": "163031004",
+                                    "display": "O/E - Diastolic BP reading"
+                                }
+                            ],
+                            "text": "O/E Diastolic BP reading"
+                        },
+                        "valueQuantity": {
+                            "value": 72,
+                            "unit": "mm[Hg]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation1-Topic3-flat-Medication-Plan-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "059015db-0c0d-4b12-b3fa-300abdc5e8a3"
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/d260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-03-28",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-03-28",
+                        "end": "2019-04-25"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "tablet(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "d260b451-9821-42de-81f9-ba86dcea2c32",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "319284000",
+                            "display": "Amlodipine 10mg tablets"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation1-Topic3-flat-Medication-Order-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "c19496d1-83e2-4438-936a-c94da1ac1bfb"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation1-Topic3-flat-Medication-Plan-1"
+                    }
+                ],
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/d260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-03-28",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-03-28",
+                        "end": "2019-04-25"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "tablet(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic4-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "055db718-1a8e-4caf-9224-385d87e67ab9"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "2 weeks cough - white sputum - no blood, 1 week nose running, 5 days sore throat, No shortness of breath"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic4-Category-History-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "b5a1152c-f915-4d11-a455-d650b38c9706"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "82824016"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "49727002",
+                            "display": "Cough"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic4-Category-History-Observation-3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "1809bdf0-1149-454e-8376-f5d809c922b3"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "136465014"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Acute coryza"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "82272006",
+                            "display": "Common cold"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic4-Category-History-Observation-4",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "1eaaab06-41b5-4333-9028-c1d90c9e9133"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2164213014"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Sore throat"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "162397003",
+                            "display": "Pain in throat"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic4-Category-History-Observation-5",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "04168671-c28b-4096-ac5c-be703605ee9e"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "1231298013"
+                                        },
+                                        {
+                                            "url": "DescriptionDisplay",
+                                            "valueString": "Upper respiratory tract infection"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "54150009",
+                            "display": "Upper respiratory infection"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation1-Topic4-Category-Plan-Medication-Plan-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "e227f7cc-dfc2-454a-8e28-0a1c71ef126c"
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/a260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-03-28",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-03-28",
+                        "end": "2019-04-25"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "tablet(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "a260b451-9821-42de-81f9-ba86dcea2c32",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "322236009",
+                            "display": "Paracetamol 500mg tablets"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation1-Topic4-Category-Plan-Medication-Order-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "1afdd010-e1c6-470a-a8c6-450523e47c6d"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation1-Topic4-Category-Plan-Medication-Plan-1"
+                    }
+                ],
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/a60b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-03-28",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-03-28",
+                        "end": "2019-04-25"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "tablet(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic5-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "0568ea1c-15ed-47f0-99c3-d3d04c48ab13"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "51875014"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Knee pain"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "30989003",
+                            "display": "Knee pain"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic5-Category-History-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "3fc884e6-a327-4076-b4c5-6b02192c5160"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Similar problem 3 months ago - settled after 2 weeks"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic5-Category-History-Observation-3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "a2693876-dd02-4421-8575-6bd8e8e46119"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "No locking.No effusion. No giving way"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic5-Category-History-Observation-4",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "a2693876-dd02-4421-8575-6bd8e8e4611a"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2872868013"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "445241004",
+                            "display": "Postviral cough"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic5-Category-Examination-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "b5a66da1-fb5b-4c39-976f-be2c21340eb7"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "No effusion. Full range of movement. Ligaments normal"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic5-Category-Examination-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "9163a07a-bcb5-402d-8124-d8cc66b87be8"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "440282017"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "299373004",
+                            "display": "Tenderness on medial joint line of knee"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1-Topic5-Category-Plan-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "656d0ab8-6be6-4119-a538-956541e5949c"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00+00:00",
+                "issued": "2019-03-28T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Analgesia advice, try knee support daytime"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "Encounter2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "2f8f5c13-2c74-4d25-ad94-631be9e59670"
+                    }
+                ],
+                "status": "finished",
+                "type": [
+                    {
+                        "text": "Surgery Consultation"
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "participant": [
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "PPRF",
+                                        "display": "primary performer"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "REC",
+                                        "display": "recorder"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1"
+                        }
+                    }
+                ],
+                "period": {
+                    "start": "2019-05-01T10:30:00+00:00",
+                    "end": "2019-05-01T10:38:00"
+                },
+                "length": {
+                    "value": 8,
+                    "unit": "m",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "min"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Surgery Consultation",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "325851000000107",
+                            "display": "Consultation"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-A-Anxiety-With-Depression"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Anxiety with Depression",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic1-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic1-Category-Examination"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic1-Category-Social"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic1-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-E-Post-viral-cough"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Upper respiratory tract infection",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic2-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation2-Topic2-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic1-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-History-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic1-Category-Examination",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Examination",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Examination-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic1-Category-Social",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Social",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Social-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic1-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation2-Topic1-Category-Plan-Medication-Plan"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation2-Topic1-Category-Plan-Medication-Order"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Plan-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic2-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic2-Category-History-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation2-Topic2-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "date": "2019-05-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic2-Category-Plan-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation2-Topic1-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "3352c57a-a28c-4995-9826-3a8c5dbcae90"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "effectiveDateTime": "2019-05-01T10:30:00+00:00",
+                "issued": "2019-05-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Overall doing better. Mood improving. Still gets bad days. Energy levels ok. Motivation improving. Started to go walking twice a week. First counsellor appointment due in two weeks."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation2-Topic1-Category-Examination-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "1f52c366-9638-4042-8863-a1c9c357e8b4"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "effectiveDateTime": "2019-05-01T10:30:00+00:00",
+                "issued": "2019-05-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "MSE looks brighter. Not anxious. No DSH/hallucinations/abnormal thoughts"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation2-Topic1-Category-Social-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "1c388cca-8d1d-40d3-8049-bef119eeda27"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2713011000000113"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "1082641000000106",
+                            "display": "Alcohol units consumed per week"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "effectiveDateTime": "2019-05-01T10:30:00+00:00",
+                "issued": "2019-05-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 2,
+                    "unit": "units/week"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation2-Topic1-Category-Plan-Medication-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "19e81871-5cad-4a0e-a387-6121b2f2bafd"
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/b260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-05-01",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY, Patient Notes: Continue citalopram 20mg od. Encourage to take every day"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-05-01",
+                        "end": "2019-05-29"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "capsule(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "b260b451-9821-42de-81f9-ba86dcea2c32",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "321987003",
+                            "display": "Citalopram 20mg tablets"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation2-Topic1-Category-Plan-Medication-Order",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "3bd272e2-3002-4eed-9730-325eb61665a5"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation2-Topic1-Category-Plan-Medication-Plan"
+                    }
+                ],
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/b260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-05-01",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-05-01",
+                        "end": "2019-05-29"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "capsule(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation2-Topic1-Category-Plan-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "0a376ee5-a69f-4056-9b46-dea04cda92ad"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "effectiveDateTime": "2019-05-01T10:30:00+00:00",
+                "issued": "2019-05-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Review in 4 weeks or earlier if problems"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation2-Topic2-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "1490bbdc-9c18-4631-afa5-615253b9b963"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "effectiveDateTime": "2019-05-01T10:30:00+00:00",
+                "issued": "2019-05-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Patient reports the condition has cleared but develops cough when lies down to sleep."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation2-Topic2-Category-Plan-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "2b45be94-e119-484e-9de6-66685145742e"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "effectiveDateTime": "2019-05-01T10:30:00+00:00",
+                "issued": "2019-05-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Recommend that before sleep, patient has a hot drink. Sleep with head in elevated position."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "Encounter3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Encounter-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "f597338b-b2f0-4cab-8222-c69789045d8"
+                    }
+                ],
+                "status": "finished",
+                "type": [
+                    {
+                        "text": "Surgery Consultation"
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "participant": [
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "PPRF",
+                                        "display": "primary performer"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1"
+                        }
+                    },
+                    {
+                        "type": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+                                        "code": "REC",
+                                        "display": "recorder"
+                                    }
+                                ]
+                            }
+                        ],
+                        "individual": {
+                            "reference": "Practitioner/1"
+                        }
+                    }
+                ],
+                "period": {
+                    "start": "2019-06-01T10:30:00+00:00",
+                    "end": "2019-06-01T10:38:00+00:00"
+                },
+                "length": {
+                    "value": 8,
+                    "unit": "m",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "min"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Surgery Consultation",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "600711000000114"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "325851000000107",
+                            "display": "Consultation"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-A-Anxiety-With-Depression"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Anxiety with Depression",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic1-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic1-Category-Examination"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic1-Category-Social"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic1-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-B-Swollen-Legs"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Swollen legs",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "63541000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "25851000000105",
+                            "display": "Topic (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic2-Category-History"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic2-Category-Examination"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "List/Consultation3-Topic2-Category-Plan"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic1-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-History-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic1-Category-Examination",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Examination",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Examination-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic1-Category-Social",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Social",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Social-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic1-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation3-Topic1-Category-Plan-Medication-Plan"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationRequest/Consultation3-Topic1-Category-Plan-Medication-Order"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Plan-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic2-Category-History",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "History",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-History-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic2-Category-Examination",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Examination",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-5"
+                        }
+                    },
+                    {
+                        "item": {
+                            "display": "Pathology report items are not supported by the provider system"
+                        }
+                    },
+                    {
+                        "item": {
+                            "display": "Pathology report items are not supported by the provider system"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "id": "Consultation3-Topic2-Category-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Plan",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "62271000000118"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "24781000000107",
+                            "display": "Category (EHR)"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "date": "2019-06-01T10:30:00+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "system",
+                            "display": "Sorted by System"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Plan-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic1-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "8b043e08-89c1-4ba9-be15-f47acd8903bd"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Overall doing better. Mood slowly improving. Still gets bad days. Energy levels ok. Motivation improving. Continues to go walking twice a week. Attended first counsellor appointment but not sure if it helped."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic1-Category-Examination-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "c67257f4-a46c-4c36-a75d-f325212755fb"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "MSE smiling. Not anxious. No DSH/hallucinations/abnormal thoughts"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic1-Category-Social-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "3408a795-074c-4134-8ffb-25416c07b899"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2713011000000113"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "1082641000000106",
+                            "display": "Alcohol units consumed per week"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 2,
+                    "unit": "units/week"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation3-Topic1-Category-Plan-Medication-Plan",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "626a674a-3610-4235-8575-348119ec0367"
+                    }
+                ],
+                "status": "completed",
+                "intent": "plan",
+                "medicationReference": {
+                    "reference": "Medication/f260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-06-01",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-06-01",
+                        "end": "2019-06-29"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "capsule(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "f260b451-9821-42de-81f9-ba86dcea2c32",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "321987003",
+                            "display": "Citalopram 20mg tablets"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "Consultation3-Topic1-Category-Plan-Medication-Order",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                                    "code": "acute",
+                                    "display": "Acute"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "aba514c4-8e6d-470e-b12c-c93e962f00e7"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation3-Topic1-Category-Plan-Medication-Plan"
+                    }
+                ],
+                "status": "completed",
+                "intent": "order",
+                "medicationReference": {
+                    "reference": "Medication/f260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "authoredOn": "2019-06-01",
+                "recorder": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosageInstruction": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ],
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2019-06-01",
+                        "end": "2019-06-29"
+                    },
+                    "quantity": {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1",
+                                "valueString": "capsule(s)"
+                            }
+                        ],
+                        "value": 28
+                    },
+                    "expectedSupplyDuration": {
+                        "value": 28,
+                        "unit": "day",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "d"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic1-Category-Plan-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "689d60ee-40f5-4ff9-9a35-221c2044e3e7"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Review in 2 months or earlier if problems."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-History-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "541efff5-68a8-413b-aa70-5b4d9f2d5ccc"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "4 months - bilateral swollen lower legs"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-Examination-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "8c4908e8-0236-4eab-8d59-09295bd06911"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "3008650016"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "703421000",
+                            "display": "Temperature"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 37.1,
+                    "unit": "C",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "Cel"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-Examination-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "a7efc48a-fd8e-4dc8-8b90-976a760d6e71"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2748921000000116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "1097811000000106",
+                            "display": "Arterial oxygen saturation breathing room air at rest"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 97,
+                    "unit": "%",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "%"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-Examination-Observation-3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "f9b9b95b-1d2b-4eef-8534-be61a8a3f8a4"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "143107019"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "86290005",
+                            "display": "Respiratory rate"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 16,
+                    "unit": "breaths per minute",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "{resps}/min"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-Examination-Observation-4",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "9e0bf96e-7e04-4b3e-8145-45e8bc0e0858"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "406493011"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "271637005",
+                            "display": "Pulse irregularly irregular"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 70,
+                    "unit": "per minute",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "{beats}/min"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-Examination-Observation-5",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "f2aa2fa5-cceb-4ae8-bde7-5efee2601a7d"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Swelling lower legs bilaterally. Mild pitting oedema. Heart sounds normal. Chest clear. No distress. Abdomen normal. No cervical lymphadenopathy. Throat normal. Ears normal. Swelling has noticeably reduced from examiniation two months ago. Blood count and ECG have not identified any cause."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-Plan-Observation-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "d2df1eed-f03e-4137-925c-8b332ef4c656"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "350678016"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "234050002",
+                            "display": "Venous insufficiency of leg"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Likely venous insufficiency"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation3-Topic2-Category-Plan-Observation-2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "4a72cb08-baff-4ec8-a3bb-ed0f993f652e"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "87901000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter3"
+                },
+                "effectiveDateTime": "2019-06-01T10:30:00+00:00",
+                "issued": "2019-06-01T10:30:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "comment": "Refer to nurse for dopplers and if suitable support stockings."
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "PractitionerRole",
+                "id": "e0244de8-07ef-4274-9f7a-d7067bcc8d21",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-PractitionerRole-1"
+                    ]
+                },
+                "practitioner": {
+                    "reference": "Practitioner/1"
+                },
+                "organization": {
+                    "reference": "Organization/7"
+                },
+                "code": [
+                    {
+                        "coding": [
+                            {
+                                "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/CareConnect-SDSJobRoleName-1",
+                                "code": "R0260",
+                                "display": "General Medical Practitioner"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "a60b451-9821-42de-81f9-ba86dcea2c32",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Medication-1"
+                    ]
+                },
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "56992301000001116"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "321987003",
+                            "display": "Citalopram 20mg tablets"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "Problem-A-Anxiety-With-Depression",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation1-Topic1-Category-Plan-Medication-Plan"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation1-Topic1-Category-Plan-Medication-Order"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Referral items are not supported by the provider system"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Plan-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation2-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation2-Topic1-Category-Plan-Medication-Plan"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation2-Topic1-Category-Plan-Medication-Order"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation3-Topic1-Category-Plan-Medication-Plan"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation3-Topic1-Category-Plan-Medication-Order"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Plan-Observation-1"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "D06C0517-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "346979010"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "onsetDateTime": "2019-03-28T10:30:00+00:00",
+                "assertedDate": "2019-03-28T10:30:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "Problem-B-Swollen-Legs",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-5"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Test Request items are not supported by the provider system"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-5"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Plan-Observation-1"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "62658072-28af-47e5-b81c-bc0521d5c41c"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2729461000000110"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Swollen leg"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "449614009",
+                            "display": "Swelling of lower limb"
+                        }
+                    ],
+                    "text": "Swollen legs"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "onsetDateTime": "2019-03-28T10:30:00+00:00",
+                "assertedDate": "2019-03-28T10:30:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                },
+                "note": [
+                    {
+                        "text": "due to obesity and poor mobility and previous DVT"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "Problem-D-URTI",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "type",
+                                "valueCode": "Parent"
+                            },
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-E-Post-viral-cough"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-5"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-3"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-4"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation1-Topic4-Category-Plan-Medication-Plan-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "MedicationRequest/Consultation1-Topic4-Category-Plan-Medication-Order-1"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "D03A94D9-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "1231298013"
+                                        },
+                                        {
+                                            "url": "DescriptionDisplay",
+                                            "valueString": "Upper respiratory tract infection"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "54150009",
+                            "display": "Upper respiratory infection"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "onsetDateTime": "2019-03-28T10:30:00+00:00",
+                "assertedDate": "2019-03-28T10:30:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "Problem-E-Post-viral-cough",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedProblemHeader-1",
+                        "extension": [
+                            {
+                                "url": "type",
+                                "valueCode": "Child"
+                            },
+                            {
+                                "url": "target",
+                                "valueReference": {
+                                    "reference": "Condition/Problem-D-URTI"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "minor"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ActualProblem-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-4"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation2-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation2-Topic2-Category-Plan-Observation-1"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://provider.nhs.uk/data-identifier",
+                        "value": "CFE8F260-4D1C-11E3-9E6B-010000001205"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2872868013"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "445241004",
+                            "display": "Postviral cough"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter2"
+                },
+                "onsetDateTime": "2019-03-28T10:30:00+00:00",
+                "assertedDate": "2019-03-28T10:30:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "6bff710a-0bdc-4c9b-b98b-40db0a107edc",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2019-03-28"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bd70-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation1-Topic1-Category-Plan-Medication-Plan"
+                    }
+                ],
+                "status": "completed",
+                "medicationReference": {
+                    "reference": "Medication/c260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "effectivePeriod": {
+                    "start": "2019-03-28",
+                    "end": "2019-04-25"
+                },
+                "dateAsserted": "2019-03-28",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosage": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "7bff710a-0bdc-4c9b-b98b-40db0a107edc",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2019-03-28"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bd70-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation1-Topic3-flat-Medication-Plan-1"
+                    }
+                ],
+                "status": "completed",
+                "medicationReference": {
+                    "reference": "Medication/d260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "effectivePeriod": {
+                    "start": "2019-03-28",
+                    "end": "2019-04-25"
+                },
+                "dateAsserted": "2019-03-28",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosage": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "d806d0aa-a2c7-4a4b-9121-e80e04c20693",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2019-03-28"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bd70-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation1-Topic4-Category-Plan-Medication-Plan-1"
+                    }
+                ],
+                "status": "completed",
+                "medicationReference": {
+                    "reference": "Medication/a260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "effectivePeriod": {
+                    "start": "2019-03-28",
+                    "end": "2019-04-25"
+                },
+                "dateAsserted": "2019-03-28",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosage": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "5a437365-7aa0-4c4f-b79e-75879bc8e14e",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2019-05-01"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bd70-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation2-Topic1-Category-Plan-Medication-Plan"
+                    }
+                ],
+                "status": "completed",
+                "medicationReference": {
+                    "reference": "Medication/b260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "effectivePeriod": {
+                    "start": "2019-05-01",
+                    "end": "2019-05-29"
+                },
+                "dateAsserted": "2019-05-01",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosage": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "8f78cb68-7f02-4f8c-9b85-05abc743ec7a",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationStatement-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatementLastIssueDate-1",
+                        "valueDateTime": "2019-06-01"
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescribingAgency-1",
+                                    "code": "prescribed-at-gp-practice",
+                                    "display": "Prescribed at GP practice"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "bb49bd70-bca8-11eb-b888-1002b58598b4"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "MedicationRequest/Consultation3-Topic1-Category-Plan-Medication-Plan"
+                    }
+                ],
+                "status": "completed",
+                "medicationReference": {
+                    "reference": "Medication/f260b451-9821-42de-81f9-ba86dcea2c32"
+                },
+                "effectivePeriod": {
+                    "start": "2019-06-01",
+                    "end": "2019-06-29"
+                },
+                "dateAsserted": "2019-06-01",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "taken": "unk",
+                "note": [
+                    {
+                        "text": "Pharmacy Notes: NOTES FOR PHARMACY"
+                    }
+                ],
+                "dosage": [
+                    {
+                        "text": "TAKE ONE DAILY",
+                        "patientInstruction": "INSTRUCTIONS FOR PATIENT"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Consultations - medications contained in consultations",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/GPConnect-SecondaryListValues-1",
+                            "code": "consultations-medications-contained-in-consultations",
+                            "display": "Consultations - medications contained in consultations"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2018-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/8f78cb68-7f02-4f8c-9b85-05abc743ec7a"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/5a437365-7aa0-4c4f-b79e-75879bc8e14e"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/6bff710a-0bdc-4c9b-b98b-40db0a107edc"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/7bff710a-0bdc-4c9b-b98b-40db0a107edc"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/d806d0aa-a2c7-4a4b-9121-e80e04c20693"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Consultations - uncategorised data contained in consultations",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/GPConnect-SecondaryListValues-1",
+                            "code": "consultations-uncategorised-data-contained-in-consultations",
+                            "display": "Consultations - uncategorised data contained in consultations"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2018-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Plan-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-5"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic3-flat-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic3-flat-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-5"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-5"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Plan-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-History-Observation-2"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Immunisations",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1102181000000102",
+                            "display": "Immunisations"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2019-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Immunization/eba25af1-5b74-4790-aa5a-2134fd27ad45"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Location",
+                "id": "17",
+                "meta": {
+                    "versionId": "636064088100870233",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Location-1"
+                    ]
+                },
+                "name": "COXWOLD Surgery",
+                "address": {
+                    "line": [
+                        "NHS Digital Test Data Manager",
+                        "Whitehall 2"
+                    ],
+                    "city": "Leeds",
+                    "district": "West Yorkshire",
+                    "postalCode": "LS1 4HR",
+                    "country": "UK"
+                },
+                "managingOrganization": {
+                    "reference": "Organization/7"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Immunization",
+                "id": "eba25af1-5b74-4790-aa5a-2134fd27ad45",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Immunization-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ParentPresent-1",
+                        "valueBoolean": true
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-DateRecorded-1",
+                        "valueDateTime": "2019-06-28T10:00:00+01:00"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-VaccinationProcedure-1",
+                        "valueCodeableConcept": {
+                            "coding": [
+                                {
+                                    "system": "http://snomed.info/sct",
+                                    "code": "170378007",
+                                    "display": "First hepatitis A vaccination"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "urn:uuid:eba25af1-5b74-4790-aa5a-2134fd27ad75"
+                    }
+                ],
+                "status": "completed",
+                "notGiven": false,
+                "vaccineCode": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v3/NullFlavor",
+                            "code": "UNK"
+                        }
+                    ],
+                    "text": "Unknown"
+                },
+                "patient": {
+                    "reference": "Patient/2"
+                },
+                "encounter": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "date": "2019-06-28",
+                "primarySource": true,
+                "location": {
+                    "reference": "Location/17"
+                },
+                "manufacturer": {
+                    "reference": "Organization/7"
+                },
+                "lotNumber": "AAJN11K",
+                "expirationDate": "2019-12-15",
+                "site": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "368209003",
+                            "display": "Right upper arm"
+                        }
+                    ]
+                },
+                "route": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "34206005",
+                            "display": "Subcutaneous route"
+                        }
+                    ]
+                },
+                "doseQuantity": {
+                    "value": 0.5,
+                    "system": "http://unitsofmeasure.org",
+                    "code": "ml"
+                },
+                "practitioner": [
+                    {
+                        "role": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/stu3/valueset-immunization-role.html",
+                                    "code": "AP"
+                                }
+                            ]
+                        },
+                        "actor": {
+                            "reference": "Practitioner/1"
+                        }
+                    }
+                ],
+                "note": [
+                    {
+                        "text": "Notes on adminstration of vaccine"
+                    }
+                ],
+                "explanation": {
+                    "reason": [
+                        {
+                            "coding": [
+                                {
+                                    "system": "http://snomed.info/sct",
+                                    "code": "171279008",
+                                    "display": "Immunisation due"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "vaccinationProtocol": [
+                    {
+                        "doseSequence": 1,
+                        "seriesDoses": 3,
+                        "targetDisease": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "http://snomed.info/sct",
+                                        "code": "40468003",
+                                        "display": "Viral hepatitis, type A"
+                                    }
+                                ]
+                            }
+                        ],
+                        "doseStatus": {
+                            "coding": [
+                                {
+                                    "system": "http://hl7.org/fhir/stu3/valueset-vaccination-protocol-dose-status.html",
+                                    "code": "count",
+                                    "display": "Counts"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "ImmunisationsProblem",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Immunization/eba25af1-5b74-4790-aa5a-2134fd27ad45"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "D06C0517-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "assertedDate": "2020-12-01T00:00:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Outbound referral",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "792931000000107",
+                            "display": "Outbound referral"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2019-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "ReferralRequest/Consultation1-Topic1-Category-Plan-ReferralRequest-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "ReferralRequest/Consultation1-Topic5-Category-Plan-ReferralRequest-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "Consultation1-Topic5-Category-Plan-ReferralRequest-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ReferralRequest-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "B154D1A3-D631-49BD-8B67-2F76D7D85865"
+                    },
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ubr-number",
+                        "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4"
+                    }
+                ],
+                "status": "unknown",
+                "intent": "order",
+                "priority": "routine",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "authoredOn": "2019-03-28T10:30:00+00:00",
+                "requester": {
+                    "agent": {
+                        "reference": "Practitioner/1"
+                    }
+                },
+                "recipient": [
+                    {
+                        "reference": "Practitioner/1",
+                        "display": "Dr Dave"
+                    }
+                ],
+                "reasonCode": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "308447003",
+                                "display": "Referral to physiotherapist"
+                            }
+                        ]
+                    }
+                ],
+                "description": "Referral due to swollen legs"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ReferralRequest",
+                "id": "Consultation1-Topic1-Category-Plan-ReferralRequest-1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ReferralRequest-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "B154D1A3-D631-49BD-8B67-2F76D7D85866"
+                    },
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ubr-number",
+                        "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce5"
+                    }
+                ],
+                "status": "unknown",
+                "intent": "order",
+                "priority": "routine",
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "authoredOn": "2019-03-28T10:30:00+00:00",
+                "requester": {
+                    "agent": {
+                        "reference": "Practitioner/1"
+                    }
+                },
+                "recipient": [
+                    {
+                        "reference": "Practitioner/1",
+                        "display": "Dr Dave"
+                    }
+                ],
+                "reasonCode": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "308448008",
+                                "display": "Referral to counselor"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "ReferralsProblem",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "ReferralRequest/Consultation1-Topic5-Category-Plan-ReferralRequest-1"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "D06C0517-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "assertedDate": "2020-12-01T00:00:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Uncategorised data",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "826501000000100",
+                            "display": "Miscellaneous record"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2019-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1_topic2_category_Examination_Observation_1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1_topic2_category_Examination_Observation_2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1_topic2_category_Examination_Observation_3"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1_topic2_category_Examination_Observation_1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "urn:uuid:eba25af1-5b74-4790-aa5a-2134fd27ad77"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "3008650016"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Temperature"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "703421000",
+                            "display": "Temperature"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00",
+                "issued": "2019-04-03T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 36.7,
+                    "unit": "C",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "Cel"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1_topic2_category_Examination_Observation_2",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "urn:uuid:eba25af1-5b74-4790-aa5a-2134fd27ad78"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "2748921000000116"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Arterial oxygen saturation on room air at rest"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "1097811000000106",
+                            "display": "Arterial oxygen saturation breathing room air at rest"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00",
+                "issued": "2019-04-03T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 96,
+                    "unit": "%",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "%"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "Consultation1_topic2_category_Examination_Observation_3",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "urn:uuid:eba25af1-5b74-4790-aa5a-2134fd27ad79"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "143107019"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "Respiratory rate"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": " 86290005",
+                            "display": "Respiratory rate"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "context": {
+                    "reference": "Encounter/Encounter1"
+                },
+                "effectiveDateTime": "2019-03-28T10:30:00",
+                "issued": "2019-04-03T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Practitioner/1"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 16,
+                    "unit": "breaths per minute",
+                    "system": "http://unitsofmeasure.org",
+                    "code": "{resps}/min"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "UncategorisedDataProblem",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "Observation/Consultation1_topic2_category_Examination_Observation_1"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "D06C0517-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "assertedDate": "2020-12-01T00:00:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Problems",
+                "code": {
+                    "coding": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "DescriptionID",
+                                            "valueId": "1570241000000115"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "717711000000103",
+                            "display": "Problems"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2019-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Condition/Problem-A-Anxiety-With-Depression"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/Problem-B-Swollen-Legs"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/Problem-D-URTI"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Condition/Problem-E-Post-viral-cough"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Problems - medications related to problems",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/GPConnect-SecondaryListValues-1",
+                            "code": "problems-medications-related-to-problems",
+                            "display": "Problems - medications related to problems"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2018-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/8f78cb68-7f02-4f8c-9b85-05abc743ec7a"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/5a437365-7aa0-4c4f-b79e-75879bc8e14e"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/6bff710a-0bdc-4c9b-b98b-40db0a107edc"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "MedicationStatement/d806d0aa-a2c7-4a4b-9121-e80e04c20693"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Problems - uncategorised data related to problems",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "https://fhir.hl7.org.uk/STU3/CodeSystem/GPConnect-SecondaryListValues-1",
+                            "code": "problems-uncategorised-data-related-to-problems",
+                            "display": "Problems - uncategorised data related to problems"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2018-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Social-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-Plan-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Social-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic1-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Examination-Observation-5"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic2-Category-Plan-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic1-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Examination-Observation-5"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation3-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-2"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-3"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic4-Category-History-Observation-5"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation1-Topic5-Category-History-Observation-4"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic2-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic2-Category-Plan-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-History-Observation-1"
+                        }
+                    },
+                    {
+                        "item": {
+                            "reference": "Observation/Consultation2-Topic1-Category-Plan-Observation-1"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "List",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-List-1"
+                    ]
+                },
+                "status": "current",
+                "mode": "snapshot",
+                "title": "Investigations and results",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "887191000000108",
+                            "display": "Investigations and results"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "date": "2018-03-01T10:57:34+00:00",
+                "orderedBy": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/list-order",
+                            "code": "event-date"
+                        }
+                    ]
+                },
+                "entry": [
+                    {
+                        "item": {
+                            "reference": "DiagnosticReport/efae5859-28df-4e7d-be91-6df56d8215e4"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "ProcedureRequest",
+                "id": "d9df1431-22ac-462a-946a-f195f6c639af",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProcedureRequest-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "7e9bbd01-4e52-420d-b05b-48bc671d6708"
+                    }
+                ],
+                "status": "active",
+                "intent": "order",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "26604007",
+                            "display": "FBC - Full blood count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "requester": {
+                    "agent": {
+                        "reference": "Practitioner/1",
+                        "display": "GILBERT"
+                    }
+                },
+                "performer": {
+                    "reference": "Organization/7",
+                    "display": "COXWOLD Surgery"
+                },
+                "note": [
+                    {
+                        "text": "FBC"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DiagnosticReport",
+                "id": "efae5859-28df-4e7d-be91-6df56d8215e4",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "1b663fc5-9dec-49c0-90ed-18a7cfa5a6b2"
+                    }
+                ],
+                "basedOn": [
+                    {
+                        "reference": "ProcedureRequest/d9df1431-22ac-462a-946a-f195f6c639af"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "721981007",
+                            "display": "Diagnostic studies report"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-03T12:00:00+00:00",
+                "performer": [
+                    {
+                        "actor": {
+                            "reference": "Organization/7",
+                            "display": "COXWOLD Surgery"
+                        }
+                    }
+                ],
+                "specimen": [
+                    {
+                        "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                    }
+                ],
+                "result": [
+                    {
+                        "reference": "Observation/7ec12071-b737-4ce8-8a91-2ea36d94464f"
+                    },
+                    {
+                        "reference": "Observation/dacb177a-9501-4dcc-8b22-b941791ae0db"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "7ec12071-b737-4ce8-8a91-2ea36d94464f",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "f29457fd-eb4c-48d5-a911-8c2badd6e2bc"
+                    }
+                ],
+                "status": "unknown",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "Comment note"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "comment": "Some filing comments added at the GP practice"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Specimen",
+                "id": "756a8361-79ce-4561-afcb-a91fe19df123",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "1b663fc5-9dec-49c0-9eed-18a7cfa5a6b2"
+                    }
+                ],
+                "status": "available",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "122555007",
+                            "display": "Venous blood specimen"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "receivedTime": "2017-11-01T15:00:00+00:00",
+                "collection": {
+                    "collectedDateTime": "2019-04-01T11:00:00+00:00"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "dacb177a-9501-4dcc-8b22-b941791ae0db",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965d5"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "26604007",
+                            "display": "FBC - Full blood count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "related": [
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/dacb177a-9501-4dcc-8b22-b941791ae0dc"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/32685afe-1d46-4d98-8279-39b9e96ee914"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/770b982d-be09-4744-a5d7-54e757947ffe"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/0a8aba3d-6b29-4dba-9c64-3a47516cc5eb"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/ddc43c3a-2863-4d6f-a926-162f5a4174b1"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/9825b7cf-de29-4c07-9b84-4af04dbf8233"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/e732e681-3a89-4433-a37b-3767dd19d809"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/2a604bea-1ef4-4cb1-97a0-f2a160f12679"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/704b6bb2-a1c0-429b-b901-c641e70345ec"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/53f4132c-0168-4327-8d69-560b13f5bb4e"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/c9e03e92-78b8-4e8e-9785-cbd9424e9380"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/9c61ad77-8c17-41aa-b795-f0fcb9f983d5"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/f67cb109-0890-4e47-9126-86da677c7008"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/1f2e71db-b9aa-4e4f-9a78-87f99fefc8bf"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/a23b563d-765a-4032-8dd3-c03178224f35"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/fedb7c2d-337c-435c-9169-612349783b5a"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/f9070943-7460-413a-a608-e15334b6e1d9"
+                        }
+                    },
+                    {
+                        "type": "has-member",
+                        "target": {
+                            "reference": "Observation/66acb40a-e241-474a-92b5-c74f9aa6a854"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "dacb177a-9501-4dcc-8b22-b941791ae0dc",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965d6"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022541000000102",
+                            "display": "Total white cell count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 5.7000000000000002,
+                    "unit": "10*9/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 3.5
+                        },
+                        "high": {
+                            "value": 11
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "32685afe-1d46-4d98-8279-39b9e96ee914",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965d7"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022451000000103",
+                            "display": "Red blood cell count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 4.5700000000000003,
+                    "unit": "10*12/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "text": "less than 3.8 to 5"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "770b982d-be09-4744-a5d7-54e757947ffe",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965d8"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022431000000105",
+                            "display": "Haemoglobin estimation"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 142,
+                    "unit": "g/dL"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 115
+                        },
+                        "high": {
+                            "value": 150
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "0a8aba3d-6b29-4dba-9c64-3a47516cc5eb",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965d9"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022291000000105",
+                            "display": "Haematocrit"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 0.42699999999999999,
+                    "unit": "%"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "text": "greater than 0.36 and less than 0.46"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "ddc43c3a-2863-4d6f-a926-162f5a4174b1",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965da"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022491000000106",
+                            "display": "Mean corpuscular volume"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 93.400000000000006,
+                    "unit": "fL"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 80
+                        },
+                        "high": {
+                            "value": 99
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "9825b7cf-de29-4c07-9b84-4af04dbf8233",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965db"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022471000000107",
+                            "display": "Mean corpuscular haemoglobin"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 31.100000000000001,
+                    "unit": "pg"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 27.5
+                        },
+                        "high": {
+                            "value": 32.5
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "e732e681-3a89-4433-a37b-3767dd19d809",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965dc"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022481000000109",
+                            "display": "Mean corpuscular haemoglobin concentration"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 333,
+                    "unit": "g/dL"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 310
+                        },
+                        "high": {
+                            "value": 350
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "2a604bea-1ef4-4cb1-97a0-f2a160f12679",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965dd"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022651000000100",
+                            "display": "Platelet count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 206,
+                    "unit": "10*9/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 140
+                        },
+                        "high": {
+                            "value": 400
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "704b6bb2-a1c0-429b-b901-c641e70345ec",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965de"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022551000000104",
+                            "display": "Neutrophil count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 2.7599999999999998,
+                    "unit": "10*9/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 1.7
+                        },
+                        "high": {
+                            "value": 8
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "53f4132c-0168-4327-8d69-560b13f5bb4e",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965df"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1015471000000105",
+                            "display": "Percentage neutrophils"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "ST JAMES'S UNIVERSITY HOSPITAL"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 77.700000000000003,
+                    "unit": "%"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "c9e03e92-78b8-4e8e-9785-cbd9424e9380",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e0"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022581000000105",
+                            "display": "Lymphocyte count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 2.1200000000000001,
+                    "unit": "10*9/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 1
+                        },
+                        "high": {
+                            "value": 4
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "9c61ad77-8c17-41aa-b795-f0fcb9f983d5",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e1"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1015481000000107",
+                            "display": "Percentage lymphocytes"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 14.300000000000001,
+                    "unit": "%"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "f67cb109-0890-4e47-9126-86da677c7008",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e2"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022591000000107",
+                            "display": "Monocyte count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 0.47999999999999998,
+                    "unit": "10*9/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "text": "greater than 0.2 to greater than 0.8"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "1f2e71db-b9aa-4e4f-9a78-87f99fefc8bf",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e3"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1015491000000109",
+                            "display": "Percentage monocytes"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 7.0999999999999996,
+                    "unit": "%"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "a23b563d-765a-4032-8dd3-c03178224f35",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e4"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022561000000101",
+                            "display": "Eosinophil count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 0.28999999999999998,
+                    "unit": "10*9/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "text": "greater than 0.04 to greater than 0.4"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "fedb7c2d-337c-435c-9169-612349783b5a",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e5"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1015561000000104",
+                            "display": "Percentage eosinophils"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 0.90000000000000002,
+                    "unit": "%"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "f9070943-7460-413a-a608-e15334b6e1d9",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e6"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1022571000000108",
+                            "display": "Basophil count"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 0.059999999999999998,
+                    "unit": "10*9/L"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                },
+                "referenceRange": [
+                    {
+                        "low": {
+                            "value": 0.02
+                        },
+                        "high": {
+                            "value": 0.10
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "66acb40a-e241-474a-92b5-c74f9aa6a854",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "2af46949-4938-4c57-bad4-c4363e1965e7"
+                    }
+                ],
+                "status": "final",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "394595002",
+                                "display": "Pathology"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "1015501000000103",
+                            "display": "Percentage basophils"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "issued": "2019-04-06T12:00:00+00:00",
+                "performer": [
+                    {
+                        "reference": "Organization/7",
+                        "display": "COXWOLD Surgery"
+                    }
+                ],
+                "valueQuantity": {
+                    "value": 0,
+                    "unit": "%"
+                },
+                "specimen": {
+                    "reference": "Specimen/756a8361-79ce-4561-afcb-a91fe19df123"
+                }
+            }
+        },
+        {
+            "fhir_comments": [
+                " part 2 "
+            ],
+            "resource": {
+                "resourceType": "Specimen",
+                "id": "756a8361-79ce-4561-afcb-a91fe19df124",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://tools.ietf.org/html/rfc4122",
+                        "value": "1b663fc5-9dec-49c0-9eed-18a7cfa5a6b3"
+                    }
+                ],
+                "status": "available",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "122555007",
+                            "display": "Venous blood specimen"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/2",
+                    "display": "SKELLY, Horace"
+                },
+                "receivedTime": "2017-11-01T15:00:00+00:00",
+                "collection": {
+                    "collectedDateTime": "2019-04-01T11:00:00+00:00"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "InvestigationsProblem",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-ProblemSignificance-1",
+                        "valueCode": "major"
+                    },
+                    {
+                        "url": "https://fhir.hl7.org.uk/STU3/StructureDefinition/Extension-CareConnect-RelatedClinicalContent-1",
+                        "valueReference": {
+                            "reference": "DiagnosticReport/efae5859-28df-4e7d-be91-6df56d8215e4"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+                        "value": "D06C0517-4D1C-11E3-A2DD-010000000161"
+                    }
+                ],
+                "clinicalStatus": "active",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/condition-category",
+                                "code": "problem-list-item",
+                                "display": "Problem List Item"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "231504006",
+                            "display": "Mixed anxiety and depressive disorder"
+                        }
+                    ],
+                    "text": "Anxiety with depression"
+                },
+                "subject": {
+                    "reference": "Patient/2"
+                },
+                "assertedDate": "2020-12-01T00:00:00+00:00",
+                "asserter": {
+                    "reference": "Practitioner/1"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Practitioner",
+                "id": "1",
+                "meta": {
+                    "versionId": "1469444400000",
+                    "lastUpdated": "2016-07-25T12:00:00.000+01:00",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSCommunication-1",
+                        "extension": [
+                            {
+                                "url": "language",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-HumanLanguage-1",
+                                            "code": "de",
+                                            "display": "German"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-NHSCommunication-1",
+                        "extension": [
+                            {
+                                "url": "language",
+                                "valueCodeableConcept": {
+                                    "coding": [
+                                        {
+                                            "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-HumanLanguage-1",
+                                            "code": "en",
+                                            "display": "English"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/sds-user-id",
+                        "value": "G13579135"
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "usual",
+                        "family": "Gilbert",
+                        "given": [
+                            "Nichole"
+                        ],
+                        "prefix": [
+                            "Miss"
+                        ]
+                    }
+                ],
+                "gender": "female"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "1",
+                "meta": {
+                    "versionId": "1469444400000",
+                    "lastUpdated": "2016-07-25T12:00:00.000+01:00",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                        "value": "GPC001"
+                    }
+                ],
+                "name": "GP Connect Demonstrator",
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "12345678",
+                        "use": "work"
+                    }
+                ],
+                "address": [
+                    {
+                        "use": "work",
+                        "line": [
+                            "23 Main Street",
+                            "Pudsey"
+                        ],
+                        "city": "Leeds",
+                        "district": "West Yorkshire",
+                        "postalCode": "GPC 111"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "D7AF52BA-79BA-4AF8-9010-F0C2DF916CEC",
+                "meta": {
+                    "versionId": "8017752596891037527",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "D7AF52BA-79BA-4AF8-9010-F0C2DF916CEC"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "text": "(Absent Attachment - Non-existent ID)"
+                },
+                "subject": {
+                    "reference": "Patient/C71B9A8D-26CD-43D9-9030-F6C650879B37"
+                },
+                "created": "2020-12-22T14:53:00+00:00",
+                "indexed": "2020-12-22T14:55:58.567+00:00",
+                "custodian": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                },
+                "description": "(Absent Attachment - Non-existent ID)",
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "application/msword",
+                            "url": "{{request.baseUrl}}/B82617/STU3/1/gpconnect/documents/fhir/Binary/non-existing-id",
+                            "size": 13
+                        }
+                    }
+                ],
+                "context": {
+                    "encounter": {
+                        "reference": "Encounter/A44B64EA-172B-4EF5-8809-3FF24F5613C1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "79e2c371-e924-437a-bb20-27e86760a6f1",
+                "meta": {
+                    "versionId": "8017752596891037527",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "D7AF52BA-79BA-4AF8-9010-F0C2DF916CEC"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "text": "(Absent Attachment - Missing URL)"
+                },
+                "subject": {
+                    "reference": "Patient/C71B9A8D-26CD-43D9-9030-F6C650879B37"
+                },
+                "created": "2020-12-22T14:54:00+00:00",
+                "indexed": "2020-12-22T14:56:58.567+00:00",
+                "custodian": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                },
+                "description": "(Absent Attachment - Missing URL)",
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "application/msword",
+                            "size": 13
+                        }
+                    }
+                ],
+                "context": {
+                    "encounter": {
+                        "reference": "Encounter/A44B64EA-172B-4EF5-8809-3FF24F5613C1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "43913840-7979-4554-9ab5-55a7a42f1900",
+                "meta": {
+                    "versionId": "8017752596891037527",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "D7AF52BA-79BA-4AF8-9010-F0C2DF916CEC"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "text": "(Valid Attachment)"
+                },
+                "subject": {
+                    "reference": "Patient/C71B9A8D-26CD-43D9-9030-F6C650879B37"
+                },
+                "created": "2020-12-22T14:53:00+00:00",
+                "indexed": "2020-12-22T14:55:58.567+00:00",
+                "custodian": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                },
+                "description": "(Valid Attachment)",
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "application/msword",
+                            "url": "{{request.baseUrl}}/B82617/STU3/1/gpconnect/documents/fhir/Binary/43913840-7979-4554-9ab5-55a7a42f1900",
+                            "size": 13
+                        }
+                    }
+                ],
+                "context": {
+                    "encounter": {
+                        "reference": "Encounter/A44B64EA-172B-4EF5-8809-3FF24F5613C1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "5E496953-065B-41F2-9577-BE8F2FBD0757"
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "DocumentReference",
+                "id": "43913840-7979-4554-9ab5-55a7a42f1852",
+                "meta": {
+                    "versionId": "8017752596891037527",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "D7AF52BA-79BA-4AF8-9010-F0C2DF916CEC"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "text": "(Valid Attachment)"
+                },
+                "subject": {
+                    "reference": "Patient/C71B9A8D-26CD-43D9-9030-F6C650879B37"
+                },
+                "created": "2020-12-22T14:53:00+00:00",
+                "indexed": "2020-12-22T14:55:58.567+00:00",
+                "custodian": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                },
+                "description": "(Valid Attachment)",
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "application/msword",
+                            "url": "{{request.baseUrl}}/B82617/STU3/1/gpconnect/documents/fhir/Binary/43913840-7979-4554-9ab5-55a7a42f1852",
+                            "size": 13
+                        }
+                    }
+                ],
+                "context": {
+                    "encounter": {
+                        "reference": "Encounter/A44B64EA-172B-4EF5-8809-3FF24F5613C1"
+                    }
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "5E496953-065B-41F2-9577-BE8F2FBD0757"
+            }
+        }
+    ]
+}

--- a/wiremock/stubs/mappings/migrateStructuredRecord_3AttachmentsWith2Absent.json
+++ b/wiremock/stubs/mappings/migrateStructuredRecord_3AttachmentsWith2Absent.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "scenarioName": "migrateStructuredRecord",
+  "requiredScenarioState": "3 Attachments with 2 Absent",
+  "request": {
+    "method": "POST",
+    "urlPattern": "/.*/STU3/1/gpconnect/fhir/Patient/[$]gpc[.]migratestructuredrecord"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "correctPatientStructuredRecordResponse3AttachmentsWith2Absent.json",
+    "headers": {
+      "Server": "nginx",
+      "Date": "{{now format='E, d MMM y HH:mm:ss z'}}",
+      "Content-Type": "application/fhir+json;charset=UTF-8",
+      "Transfer-Encoding": "chunked",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-store",
+      "X-Powered-By": "HAPI FHIR 3.0.0 REST Server (FHIR Server; FHIR 3.0.1/DSTU3)",
+      "Strict-Transport-Security":"max-age=31536000"
+    }
+  }
+}


### PR DESCRIPTION
## What

Add scenario for '3 Attachments with 2 Absent' to wiremock

## Why

We need to test that all types of Absent Attachment are handled correctly and to be able to compare that they are all dealt with correctly.  We have included attachment types where:

* The document reference points to a file which does not exist
* The document reference is missing a URL
* The document reference is a valid attachment

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
