### PR TITLE
Use the display message from OperationOutcome when GP Connect error occurs

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentComponentTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentComponentTest.java
@@ -158,7 +158,7 @@ public class GetGpcDocumentComponentTest extends BaseTaskTest {
         assertThat(gpcDocuments.get(0).getAccessedAt()).isNotNull();
         assertThat(gpcDocuments.get(0).getObjectName()).isEqualTo(absentAttachmentFilename);
         assertThat(gpcDocuments.get(0).getMessageId()).isEqualTo(documentId);
-        assertThat(gpcDocuments.get(0).getGpConnectErrorMessage()).isEqualTo("The document could not be retrieved");
+        assertThat(gpcDocuments.get(0).getGpConnectErrorMessage()).isEqualTo("No Record Found");
 
         assertDoesNotThrow(() -> storageConnector.downloadFromStorage(absentAttachmentFilename));
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/WebClientFilterService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/WebClientFilterService.java
@@ -12,13 +12,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.slf4j.MDC;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -137,13 +141,19 @@ public class WebClientFilterService {
             var exceptionMessage = String.format(REQUEST_EXCEPTION_MESSAGE, requestType, outcome);
 
             try {
-                var objectMapper = new ObjectMapper();
-                var outcomeJson = objectMapper.readTree(outcome);
-                var codes = outcomeJson.findValuesAsText("code");
+                var jsonMapper = JsonMapper
+                    .builder()
+                    .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .build();
+
+                var operationOutcome = jsonMapper.readValue(outcome, OperationOutcome.class);
+                var codes = jsonMapper.readTree(outcome).findValuesAsText("code");
+
                 var statusCode = clientResponse.statusCode();
                 var errorCode = getErrorCode(HttpStatus.resolve(statusCode.value()), codes);
 
-                return getMonoError(errorCode, exceptionMessage);
+                return getMonoError(errorCode, exceptionMessage, operationOutcome);
             } catch (JsonProcessingException e) {
                 return Mono.error(new GpConnectException(exceptionMessage));
             }
@@ -184,7 +194,7 @@ public class WebClientFilterService {
         return NACK_ERROR_20;
     }
 
-    private static Mono<ClientResponse> getMonoError(int errorCode, String exceptionMessage) {
+    private static Mono<ClientResponse> getMonoError(int errorCode, String exceptionMessage, OperationOutcome operationOutcome) {
         switch (errorCode) {
             case NACK_ERROR_6:
                 return Mono.error(new GpConnectNotFoundException(exceptionMessage));
@@ -194,7 +204,7 @@ public class WebClientFilterService {
                 return Mono.error(new EhrRequestException(exceptionMessage));
             case NACK_ERROR_20:
             default:
-                return Mono.error(new GpConnectException(exceptionMessage));
+                return Mono.error(new GpConnectException(exceptionMessage, operationOutcome));
         }
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/utils/OperationOutcomeIssueTypeDeserializer.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/utils/OperationOutcomeIssueTypeDeserializer.java
@@ -1,0 +1,21 @@
+package uk.nhs.adaptors.gp2gp.common.utils;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.hl7.fhir.dstu3.model.OperationOutcome.IssueType;
+import org.hl7.fhir.exceptions.FHIRException;
+
+import java.io.IOException;
+
+public class OperationOutcomeIssueTypeDeserializer extends JsonDeserializer<IssueType> {
+
+    @Override
+    public IssueType deserialize(JsonParser p, DeserializationContext context) throws IOException {
+        try {
+            return IssueType.fromCode(p.getText());
+        } catch (FHIRException e) {
+            throw new IOException("Failed to deserialize OperationOutcomeIssueType value: " + p.getText(), e);
+        }
+    }
+}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.gp2gp.ehr;
 
 import static uk.nhs.adaptors.gp2gp.ehr.utils.AbsentAttachmentUtils.buildAbsentAttachmentFileName;
 
+import org.junit.platform.commons.util.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -33,11 +34,11 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
 
     @Override
     public void execute(GetAbsentAttachmentTaskDefinition taskDefinition) {
-        var ehrExtractStatus = handleAbsentAttachment(taskDefinition);
+        var ehrExtractStatus = handleAbsentAttachment(taskDefinition, null);
         detectTranslationCompleteService.beginSendingCompleteExtract(ehrExtractStatus);
     }
 
-    public EhrExtractStatus handleAbsentAttachment(DocumentTaskDefinition taskDefinition) {
+    public EhrExtractStatus handleAbsentAttachment(DocumentTaskDefinition taskDefinition, String exceptionDisplay) {
         var taskId = taskDefinition.getTaskId();
 
         var fileContent = Base64Utils.toBase64String(AbsentAttachmentFileMapper.mapDataToAbsentAttachment(
@@ -56,7 +57,10 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
         storageConnectorService.uploadFile(storageDataWrapperWithMhsOutboundRequest, storagePath);
 
         return ehrExtractStatusService.updateEhrExtractStatusAccessDocument(
-            taskDefinition, storagePath, fileContent.length(), getTitle(taskDefinition)
+            taskDefinition,
+            storagePath,
+            fileContent.length(),
+            StringUtils.isBlank(exceptionDisplay) ? getTitle(taskDefinition) : exceptionDisplay
         );
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
@@ -2,7 +2,7 @@ package uk.nhs.adaptors.gp2gp.ehr;
 
 import static uk.nhs.adaptors.gp2gp.ehr.utils.AbsentAttachmentUtils.buildAbsentAttachmentFileName;
 
-import org.junit.platform.commons.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutor.java
@@ -40,7 +40,8 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
         detectTranslationCompleteService.beginSendingCompleteExtract(ehrExtractStatus);
     }
 
-    public EhrExtractStatus handleAbsentAttachment(DocumentTaskDefinition taskDefinition, Optional<String> exceptionDisplay) {
+    public EhrExtractStatus handleAbsentAttachment(DocumentTaskDefinition taskDefinition,
+                                                   Optional<String> gpcResponseError) {
         var taskId = taskDefinition.getTaskId();
 
         var fileContent = Base64Utils.toBase64String(AbsentAttachmentFileMapper.mapDataToAbsentAttachment(
@@ -62,7 +63,7 @@ public class GetAbsentAttachmentTaskExecutor implements TaskExecutor<GetAbsentAt
             taskDefinition,
             storagePath,
             fileContent.length(),
-            getErrorMessage(taskDefinition, exceptionDisplay)
+            getErrorMessage(taskDefinition, gpcResponseError)
         );
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
@@ -54,7 +54,16 @@ public class GetGpcDocumentTaskExecutor implements TaskExecutor<GetGpcDocumentTa
             ehrExtractStatus = handleValidGpcDocument(response, taskDefinition);
         } catch (GpConnectException e) {
             LOGGER.warn("Binary request returned an unexpected response", e);
-            ehrExtractStatus = getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition);
+
+            var exceptionDisplay = e.getOperationOutcome()
+                .getIssue()
+                .get(0)
+                .getDetails()
+                .getCoding()
+                .get(0)
+                .getDisplay();
+
+            ehrExtractStatus = getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition, exceptionDisplay);
         }
 
         detectTranslationCompleteService.beginSendingCompleteExtract(ehrExtractStatus);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
@@ -4,7 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Binary;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +19,8 @@ import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusService;
 import uk.nhs.adaptors.gp2gp.ehr.GetAbsentAttachmentTaskExecutor;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectException;
+
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -55,18 +60,24 @@ public class GetGpcDocumentTaskExecutor implements TaskExecutor<GetGpcDocumentTa
         } catch (GpConnectException e) {
             LOGGER.warn("Binary request returned an unexpected response", e);
 
-            var exceptionDisplay = e.getOperationOutcome()
-                .getIssue()
-                .get(0)
-                .getDetails()
-                .getCoding()
-                .get(0)
-                .getDisplay();
+            var exceptionDisplay = getDisplayFromOperationOutcome(e.getOperationOutcome());
 
             ehrExtractStatus = getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition, exceptionDisplay);
         }
 
         detectTranslationCompleteService.beginSendingCompleteExtract(ehrExtractStatus);
+    }
+
+    private Optional<String> getDisplayFromOperationOutcome(OperationOutcome operationOutcome) {
+        return Optional.ofNullable(operationOutcome)
+            .filter(oo -> oo.hasIssue() && !oo.getIssue().isEmpty())
+            .map(oo -> oo.getIssue().get(0))
+            .filter(issue -> issue.hasDetails()
+                && issue.getDetails().hasCoding()
+                && !issue.getDetails().getCoding().isEmpty())
+            .map(issue -> issue.getDetails().getCoding().get(0))
+            .filter(coding -> coding.hasDisplay() && StringUtils.isNotBlank(coding.getDisplay()))
+            .map(Coding::getDisplay);
     }
 
     private EhrExtractStatus handleValidGpcDocument(String response, GetGpcDocumentTaskDefinition taskDefinition) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcDocumentTaskExecutor.java
@@ -60,9 +60,9 @@ public class GetGpcDocumentTaskExecutor implements TaskExecutor<GetGpcDocumentTa
         } catch (GpConnectException e) {
             LOGGER.warn("Binary request returned an unexpected response", e);
 
-            var exceptionDisplay = getDisplayFromOperationOutcome(e.getOperationOutcome());
+            var gpcResponseError = getDisplayFromOperationOutcome(e.getOperationOutcome());
 
-            ehrExtractStatus = getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition, exceptionDisplay);
+            ehrExtractStatus = getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition, gpcResponseError);
         }
 
         detectTranslationCompleteService.beginSendingCompleteExtract(ehrExtractStatus);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/exception/GpConnectException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/exception/GpConnectException.java
@@ -1,11 +1,23 @@
 package uk.nhs.adaptors.gp2gp.gpc.exception;
 
+import lombok.Getter;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
+
+@Getter
 public class GpConnectException extends RuntimeException {
+
+    private OperationOutcome operationOutcome;
+
     public GpConnectException(String message) {
         super(message);
     }
 
     public GpConnectException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public GpConnectException(String message, OperationOutcome operationOutcome) {
+        super(message);
+        this.operationOutcome = operationOutcome;
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/exception/GpConnectException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/exception/GpConnectException.java
@@ -18,6 +18,6 @@ public class GpConnectException extends RuntimeException {
 
     public GpConnectException(String message, OperationOutcome operationOutcome) {
         super(message);
-        this.operationOutcome = operationOutcome.copy();
+        this.operationOutcome = operationOutcome == null ? null : operationOutcome.copy();
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/exception/GpConnectException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/exception/GpConnectException.java
@@ -18,6 +18,6 @@ public class GpConnectException extends RuntimeException {
 
     public GpConnectException(String message, OperationOutcome operationOutcome) {
         super(message);
-        this.operationOutcome = operationOutcome;
+        this.operationOutcome = operationOutcome.copy();
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutorTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutorTest.java
@@ -1,0 +1,118 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.adaptors.gp2gp.common.storage.StorageConnectorService;
+import uk.nhs.adaptors.gp2gp.gpc.DetectTranslationCompleteService;
+import uk.nhs.adaptors.gp2gp.gpc.DocumentToMHSTranslator;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class GetAbsentAttachmentTaskExecutorTest {
+    @Mock private EhrExtractStatusService ehrExtractStatusService;
+    @Mock private DocumentToMHSTranslator documentToMHSTranslator;
+    @Mock private DetectTranslationCompleteService detectTranslationCompleteService;
+    @Mock private StorageConnectorService storageConnectorService;
+
+    @InjectMocks
+    private GetAbsentAttachmentTaskExecutor getAbsentAttachmentTaskExecutor;
+
+    @Test
+    public void When_HandleAbsentAttachmentWithNoError_Expect_DefaultValueIsUsedAsError() {
+        var taskDefinition = buildAbsentAttachment(null);
+
+        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
+            taskDefinition,
+            Optional.empty());
+
+        verify(ehrExtractStatusService).updateEhrExtractStatusAccessDocument(
+            any(),
+            any(),
+            anyInt(),
+            eq("The document could not be retrieved")
+        );
+    }
+
+    @Test
+    public void When_HandleAbsentAttachmentWithJustTaskDefinitionTitle_Expect_TitleIsUsedAsError() {
+        var taskDefinition = buildAbsentAttachment("This-is-the-task-definition-title");
+
+        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
+            taskDefinition,
+            Optional.empty());
+
+        verify(ehrExtractStatusService).updateEhrExtractStatusAccessDocument(
+            any(),
+            any(),
+            anyInt(),
+            eq("This-is-the-task-definition-title")
+        );
+    }
+
+    @Test
+    public void When_HandleAbsentAttachmentWithJustGpcResponseError_Expect_GpcResponseErrorIsUsedAsError() {
+        var taskDefinition = buildAbsentAttachment(null);
+
+        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
+            taskDefinition,
+            Optional.of("This-is-the-gpc-response-error"));
+
+        verify(ehrExtractStatusService).updateEhrExtractStatusAccessDocument(
+            any(),
+            any(),
+            anyInt(),
+            eq("This-is-the-gpc-response-error")
+        );
+    }
+
+    @Test
+    public void When_HandleAbsentAttachmentWithGpcResponseErrorAndTitle_Expect_GpcResponseErrorIsUsedAsError() {
+        var taskDefinition = buildAbsentAttachment("This-is-the-task-definition-title");
+
+        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
+            taskDefinition,
+            Optional.of("This-is-the-gpc-response-error"));
+
+        verify(ehrExtractStatusService).updateEhrExtractStatusAccessDocument(
+            any(),
+            any(),
+            anyInt(),
+            eq("This-is-the-gpc-response-error")
+        );
+    }
+
+    @Test
+    public void When_HandleAbsentAttachment_Expect_AbsentAttachmentFilenameIsUsed() {
+        var taskDefinition = buildAbsentAttachment(null);
+
+        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition, Optional.empty());
+
+        verify(ehrExtractStatusService).updateEhrExtractStatusAccessDocument(
+            any(),
+            eq("AbsentAttachmentDocument-Id.txt"),
+            anyInt(),
+            any()
+        );
+    }
+
+    private static GetAbsentAttachmentTaskDefinition buildAbsentAttachment(@Nullable String title) {
+        return GetAbsentAttachmentTaskDefinition.builder()
+            .conversationId("Conversation-Id")
+            .taskId("Task-Id")
+            .originalDescription("This-is-the-original-description")
+            .toOdsCode("XX1111")
+            .documentId("Document-Id")
+            .title(title)
+            .build();
+    }
+}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetGpcDocumentTaskExecutorTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetGpcDocumentTaskExecutorTest.java
@@ -1,0 +1,224 @@
+package uk.nhs.adaptors.gp2gp.ehr;
+
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
+import uk.nhs.adaptors.gp2gp.common.storage.StorageConnectorService;
+import uk.nhs.adaptors.gp2gp.gpc.DetectTranslationCompleteService;
+import uk.nhs.adaptors.gp2gp.gpc.DocumentToMHSTranslator;
+import uk.nhs.adaptors.gp2gp.gpc.GetGpcDocumentTaskDefinition;
+import uk.nhs.adaptors.gp2gp.gpc.GetGpcDocumentTaskExecutor;
+import uk.nhs.adaptors.gp2gp.gpc.GpcClient;
+import uk.nhs.adaptors.gp2gp.gpc.exception.GpConnectException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GetGpcDocumentTaskExecutorTest {
+
+    @Mock private StorageConnectorService storageConnectorService;
+    @Mock private EhrExtractStatusService ehrExtractStatusService;
+    @Mock private GpcClient gpcClient;
+    @Mock private DocumentToMHSTranslator documentToMHSTranslator;
+    @Mock private DetectTranslationCompleteService detectTranslationCompleteService;
+    @Mock private FhirParseService fhirParseService;
+    @Mock private GetAbsentAttachmentTaskExecutor getAbsentAttachmentTaskExecutor;
+
+    @InjectMocks
+    private GetGpcDocumentTaskExecutor getGpcDocumentTaskExecutor;
+
+    private final GetGpcDocumentTaskDefinition getGpcDocumentTaskDefinition =
+        GetGpcDocumentTaskDefinition.builder().build();
+
+    @Test
+    public void When_ExecuteWithGpcClientExceptionNoOperationOutcome_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition)).thenThrow(new GpConnectException(""));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithGpcClientExceptionHasNoOperationOutcomeIssue_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        var operationOutcome = new OperationOutcome();
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithGpcClientExceptionHasEmptyOperationOutcomeIssue_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        var operationOutcome = new OperationOutcome()
+            .setIssue(
+                List.of()
+            );
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithGpcClientExceptionHasOperationOutcomeIssueHasNoDetail_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        var operationOutcome = new OperationOutcome()
+            .setIssue(
+                List.of(
+                    new OperationOutcome.OperationOutcomeIssueComponent()
+                )
+            );
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithOperationOutcomeIssueDetailHasNoCoding_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        var operationOutcome = new OperationOutcome()
+            .setIssue(
+                List.of(new OperationOutcome.OperationOutcomeIssueComponent()
+                    .setDetails(
+                        new CodeableConcept()
+                    )
+                )
+            );
+
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithOperationOutcomeIssueDetailHasEmptyCoding_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        var operationOutcome = new OperationOutcome()
+            .setIssue(
+                List.of(
+                    new OperationOutcome.OperationOutcomeIssueComponent().setDetails(
+                        new CodeableConcept().setCoding(List.of())
+                    )
+                )
+            );
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithOperationOutcomeIssueDetailCodingDisplay_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        var operationOutcome = new OperationOutcome()
+            .setIssue(
+                List.of(
+                    new OperationOutcome.OperationOutcomeIssueComponent().setDetails(
+                        new CodeableConcept().setCoding(List.of(
+                            new Coding()
+                        ))
+                    )
+                )
+            );
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithOperationOutcomeIssueDetailCodingDisplayIsEmptyString_Expect_HandleAbsentAttachmentToUseEmptyOptional() {
+        var operationOutcome = new OperationOutcome()
+            .setIssue(
+                List.of(
+                    new OperationOutcome.OperationOutcomeIssueComponent().setDetails(
+                        new CodeableConcept().setCoding(List.of(
+                            new Coding("", "", "")
+                        ))
+                    )
+                )
+            );
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.empty()
+        );
+    }
+
+    @Test
+    public void When_ExecuteWithValidOperationOutcomeIssueDetailCodingDisplay_Expect_HandleAbsentAttachmentToUseOptionalOfThis() {
+        var operationOutcome = new OperationOutcome()
+            .setIssue(
+                List.of(
+                    new OperationOutcome.OperationOutcomeIssueComponent().setDetails(
+                        new CodeableConcept().setCoding(List.of(
+                            new Coding("", "", "display-message")
+                        ))
+                    )
+                )
+            );
+
+        when(gpcClient.getDocumentRecord(getGpcDocumentTaskDefinition))
+            .thenThrow(new GpConnectException("", operationOutcome));
+
+        getGpcDocumentTaskExecutor.execute(getGpcDocumentTaskDefinition);
+
+        verify(getAbsentAttachmentTaskExecutor).handleAbsentAttachment(
+            getGpcDocumentTaskDefinition,
+            Optional.of("display-message")
+        );
+    }
+}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/OperationOutcomeIssueTypeDeserializerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/OperationOutcomeIssueTypeDeserializerTest.java
@@ -3,16 +3,12 @@ package uk.nhs.adaptors.gp2gp.utils;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
-import org.hl7.fhir.exceptions.FHIRException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import uk.nhs.adaptors.gp2gp.common.utils.OperationOutcomeIssueTypeDeserializer;
-
-import java.io.IOException;
-
 
 public class OperationOutcomeIssueTypeDeserializerTest {
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/OperationOutcomeIssueTypeDeserializerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/OperationOutcomeIssueTypeDeserializerTest.java
@@ -1,0 +1,56 @@
+package uk.nhs.adaptors.gp2gp.utils;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+import uk.nhs.adaptors.gp2gp.common.utils.OperationOutcomeIssueTypeDeserializer;
+
+import java.io.IOException;
+
+
+public class OperationOutcomeIssueTypeDeserializerTest {
+
+    @Test
+    public void When_DeserializingIssueTypeCodeWithHyphenWhichIsAValidCode_Expect_ThatMemberToBeReturned() {
+        var module = new SimpleModule();
+        module.addDeserializer(OperationOutcome.IssueType.class, new OperationOutcomeIssueTypeDeserializer());
+
+        var jsonMapper = JsonMapper.builder().build();
+        jsonMapper.registerModule(module);
+
+        final var deserializedValue = jsonMapper.convertValue("not-found", OperationOutcome.IssueType.class);
+
+        assertThat(OperationOutcome.IssueType.NOTFOUND).isEqualTo(deserializedValue);
+    }
+
+    @Test
+    public void When_DeserializingIssueTypeCodeWithoutHyphenWhichIsAValidCode_Expect_ThatMemberToBeReturned() {
+        var module = new SimpleModule();
+        module.addDeserializer(OperationOutcome.IssueType.class, new OperationOutcomeIssueTypeDeserializer());
+
+        var jsonMapper = JsonMapper.builder().build();
+        jsonMapper.registerModule(module);
+
+        final var deserializedValue = jsonMapper.convertValue("transient", OperationOutcome.IssueType.class);
+
+        assertThat(OperationOutcome.IssueType.TRANSIENT).isEqualTo(deserializedValue);
+    }
+
+    @Test
+    public void When_DeserializingIssueTypeCodeWhichIsNotAValidCode_Expect_ExceptionThrown() {
+        var module = new SimpleModule();
+        module.addDeserializer(OperationOutcome.IssueType.class, new OperationOutcomeIssueTypeDeserializer());
+
+        var jsonMapper = JsonMapper.builder().build();
+        jsonMapper.registerModule(module);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> jsonMapper.convertValue("not-a-valid-value", OperationOutcome.IssueType.class));
+    }
+}


### PR DESCRIPTION
## What

Use the display message from the OperationOutcome when GP Connect error occurs, otherwise  use the default response: "The document could not be retrieved"

## Why

The error is message current returns a generic response without indicating what the error is, it is best to use the message from the operation outcome in the response if that is available. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
