### PR TITLE
Replace deprecated wiremock-jre8-standalone package with replacement

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	testImplementation 'org.testcontainers:testcontainers:1.19.8'
 	testImplementation 'org.awaitility:awaitility:4.2.1'
 	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
-	testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone:3.0.1'
+	testImplementation 'org.wiremock:wiremock-standalone:3.6.0'
 	testImplementation 'com.squareup.okhttp3:okhttp:4.12.0'
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }


### PR DESCRIPTION
## Why

Keep packages up to date

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
