### PR TITLE
NIAD-3112 WireMock Internal Server Error

### DIFF
--- a/wiremock/README.md
+++ b/wiremock/README.md
@@ -69,6 +69,12 @@ Using the [authentication guidance], you'll need to provide the following enviro
 
 ### Changing the default record
 
+To change the patient record returned to be [Internal Server Error](stubs/__files/operationOutcomeInternalServerError.json):
+
+```shell
+curl --request PUT --data '{"state": "Internal Server Error"}' http://localhost:8110/__admin/scenarios/migrateStructuredRecord/state
+```
+
 To change the patient record returned to be [No Documents](stubs/__files/correctPatientNoDocsStructuredRecordResponse.json):
 
 ```shell

--- a/wiremock/stubs/mappings/migrateStructuredRecord InternalServerError.json
+++ b/wiremock/stubs/mappings/migrateStructuredRecord InternalServerError.json
@@ -7,7 +7,7 @@
     "urlPattern": "/.*/STU3/1/gpconnect/fhir/Patient/[$]gpc[.]migratestructuredrecord"
   },
   "response": {
-    "status": 200,
+    "status": 500,
     "bodyFileName": "operationOutcomeInternalServerError.json",
     "headers": {
       "Server": "nginx",

--- a/wiremock/stubs/mappings/migrateStructuredRecord InternalServerError.json
+++ b/wiremock/stubs/mappings/migrateStructuredRecord InternalServerError.json
@@ -1,0 +1,23 @@
+{
+  "priority": 2,
+  "scenarioName": "migrateStructuredRecord",
+  "requiredScenarioState": "Internal Server Error",
+  "request": {
+    "method": "POST",
+    "urlPattern": "/.*/STU3/1/gpconnect/fhir/Patient/[$]gpc[.]migratestructuredrecord"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "operationOutcomeInternalServerError.json",
+    "headers": {
+      "Server": "nginx",
+      "Date": "{{now format='E, d MMM y HH:mm:ss z'}}",
+      "Content-Type": "application/fhir+json;charset=UTF-8",
+      "Transfer-Encoding": "chunked",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-store",
+      "X-Powered-By": "HAPI FHIR 3.0.0 REST Server (FHIR Server; FHIR 3.0.1/DSTU3)",
+      "Strict-Transport-Security":"max-age=31536000"
+    }
+  }
+}


### PR DESCRIPTION
## What

Added mapping to WireMock which will allow us to test the retry-ability on our AWS environment by returning an Internal Server Error.
