### PR TITLE
NIAD-3050: Preserve UUIDs when mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* When mapping resources, if a UUID identifier is provided, this will be preserved in the produced XML. If a non-UUID identifier is provided, a new UUID will continue to be generated.
+
 ## [2.0.4] - 2024-06-17
 
 ### Fixed

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/RandomIdGeneratorService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/RandomIdGeneratorService.java
@@ -1,12 +1,24 @@
 package uk.nhs.adaptors.gp2gp.common.service;
 
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
 
 @Service
 public class RandomIdGeneratorService {
+
+    private static final Pattern UUID_REGEX =
+        Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
     public String createNewId() {
         return UUID.randomUUID().toString().toUpperCase();
+    }
+
+    public String createNewOrUseExistingUUID(String id) {
+        return UUID_REGEX.matcher(id).matches()
+            ? id.toUpperCase()
+            : UUID.randomUUID().toString().toUpperCase();
+
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/IdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/IdMapper.java
@@ -50,16 +50,15 @@ public class IdMapper {
     }
 
     public String getOrNewFromReference(Reference reference) {
-        if (NOT_ALLOWED.contains(reference.getReferenceElement().getResourceType())) {
+        var referenceElement = reference.getReferenceElement();
+        if (NOT_ALLOWED.contains(referenceElement.getResourceType())) {
             throw new EhrMapperException("Not allowed to use agent-related resource with IdMapper");
         }
 
-        var referenceId = reference.getReferenceElement().getIdPart();
-
+        var referenceId = referenceElement.getIdPart();
         var id = randomIdGeneratorService.createNewOrUseExistingUUID(referenceId);
-
-        MappedId defaultResourceId = new MappedId(id, false);
-        MappedId mappedId = ids.getOrDefault(reference.getReference(), defaultResourceId);
+        var defaultResourceId = new MappedId(id, false);
+        var mappedId = ids.getOrDefault(reference.getReference(), defaultResourceId);
 
         ids.put(reference.getReference(), mappedId);
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/RandomIdGeneratorServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/RandomIdGeneratorServiceTest.java
@@ -1,7 +1,6 @@
 package uk.nhs.adaptors.gp2gp.common.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.UUID;
@@ -13,16 +12,35 @@ public class RandomIdGeneratorServiceTest {
     private static final String UUID_UPPERCASE_REGEXP = "[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}";
 
     @Test
-    public void When_GeneratingRandomId_Expect_GeneratedIdIsRandomUUID() {
+    public void When_CreatingNewId_Expect_GeneratedIdIsRandomUUID() {
         String id1 = new RandomIdGeneratorService().createNewId();
         String id2 = new RandomIdGeneratorService().createNewId();
 
         assertAll(
-            () -> assertThatCode(() -> UUID.fromString(id1)).doesNotThrowAnyException(),
-            () -> assertThatCode(() -> UUID.fromString(id2)).doesNotThrowAnyException(),
             () -> assertThat(id1).isNotEqualTo(id2),
             () -> assertThat(id1).matches(UUID_UPPERCASE_REGEXP),
             () -> assertThat(id2).matches(UUID_UPPERCASE_REGEXP)
+        );
+    }
+
+    @Test
+    public void When_GeneratingIdFromExistingId_And_IdIsAValidUUID_Expect_ThatUUIDIsUsed() {
+        var uuidString = UUID.randomUUID().toString();
+
+        var generatedUUID = new RandomIdGeneratorService().createNewOrUseExistingUUID(uuidString);
+
+        assertThat(generatedUUID).isEqualTo(uuidString.toUpperCase());
+    }
+
+    @Test
+    public void When_GeneratingIdFromExistingId_And_IdIsNotAValidUUID_Expect_NewUUIDIsGenerated() {
+        var idString = "THIS-IS-NOT-A-VALID-GUID";
+
+        var generatedUUID = new RandomIdGeneratorService().createNewOrUseExistingUUID(idString);
+
+        assertAll(
+            () -> assertThat(generatedUUID).isNotEqualTo(idString),
+            () -> assertThat(generatedUUID).matches(UUID_UPPERCASE_REGEXP)
         );
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -193,6 +194,7 @@ public class AllergyStructureMapperTest {
     @BeforeEach
     public void setUp() throws IOException {
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
 
         lenient().when(codeableConceptCdMapper.mapToNullFlavorCodeableConcept(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
@@ -204,6 +206,7 @@ public class AllergyStructureMapperTest {
         lenient().when(codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(any(CodeableConcept.class),
             any(AllergyIntolerance.AllergyIntoleranceClinicalStatus.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+
 
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
         Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
@@ -26,6 +26,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,7 +70,8 @@ public class BloodPressureMapperTest {
 
     @BeforeEach
     public void setUp() {
-        when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        lenient().when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        lenient().when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
         messageContext = new MessageContext(randomIdGeneratorService);
         messageContext.initialize(new Bundle());
         bloodPressureMapper = new BloodPressureMapper(
@@ -142,6 +145,9 @@ public class BloodPressureMapperTest {
 
     @Test
     public void When_MappingBloodPressureWithCodeableConcepts_Expect_CompoundStatementXmlReturned() throws IOException {
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(any()))
+            .thenReturn("5E496953-065B-41F2-9577-BE8F2FBD0757");
+
         var jsonInput = ResourceTestFileUtils.getFileContent(BLOOD_PRESSURE_FILE_LOCATION + INPUT_BLOOD_PRESSURE_WITH_CODEABLE_CONCEPTS);
         var expectedOutput = ResourceTestFileUtils.getFileContent(
             BLOOD_PRESSURE_FILE_LOCATION + EXPECTED_BLOOD_PRESSURE_WITH_CODEABLE_CONCEPTS);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
@@ -138,7 +138,7 @@ public class ConditionLinkSetMapperTest {
         lenient().when(messageContext.getIdMapper()).thenReturn(idMapper);
         lenient().when(messageContext.getAgentDirectory()).thenReturn(agentDirectory);
         lenient().when(messageContext.getInputBundleHolder()).thenReturn(inputBundle);
-        lenient().when(randomIdGeneratorService.createNewId()).thenReturn(GENERATED_ID);
+
         IdType conditionId = buildIdType(ResourceType.Condition, CONDITION_ID);
         IdType allergyId = buildIdType(ResourceType.AllergyIntolerance, ALLERGY_ID);
         IdType immunizationId = buildIdType(ResourceType.Immunization, IMMUNIZATION_ID);
@@ -147,6 +147,8 @@ public class ConditionLinkSetMapperTest {
         lenient().when(idMapper.getOrNew(ResourceType.Observation, immunizationId)).thenReturn(IMMUNIZATION_ID);
         lenient().when(idMapper.getOrNew(any(Reference.class))).thenAnswer(answerWithObjectId(ResourceType.Condition));
         lenient().when(agentDirectory.getAgentId(any(Reference.class))).thenAnswer(answerWithObjectId());
+        lenient().when(randomIdGeneratorService.createNewId()).thenReturn(GENERATED_ID);
+
 
         conditionLinkSetMapper = new ConditionLinkSetMapper(messageContext, randomIdGeneratorService, codeableConceptCdMapper,
             new ParticipantMapper());

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -76,6 +77,7 @@ public class DiaryPlanStatementMapperTest {
         Bundle bundle = new FhirParseService().parseResource(inputJson, Bundle.class);
 
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
         when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         messageContext = new MessageContext(randomIdGeneratorService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
@@ -84,6 +85,8 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
     @BeforeEach
     public void setUp() throws IOException {
         lenient().when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        lenient().when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
+
         final String bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
         final Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);
         messageContext = new MessageContext(randomIdGeneratorService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -33,6 +33,8 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -105,6 +107,9 @@ public class EhrExtractMapperComponentTest {
             .build();
 
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID_1, TEST_ID_2, TEST_ID_3);
+        lenient().when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString()))
+            .thenReturn(TEST_ID_3);
+
         when(timestampService.now()).thenReturn(Instant.parse(TEST_DATE_TIME));
         when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
@@ -96,6 +97,7 @@ public class EncounterComponentsMapperTest {
     @BeforeEach
     public void setUp() {
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
         when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         when(codeableConceptCdMapper.mapCodeableConceptForMedication(any(CodeableConcept.class)))

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapperTest.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -139,7 +140,8 @@ public class EncounterMapperTest {
 
     @BeforeEach
     public void setUp() {
-        lenient().when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        lenient().when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
+
         messageContext = new MessageContext(randomIdGeneratorService);
         messageContext.initialize(bundle);
         lenient().when(bundle.getEntry()).thenReturn(List.of(

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -160,6 +161,7 @@ public class ImmunizationObservationStatementMapperTest {
     @BeforeEach
     public void setUp() throws IOException {
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
         when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         fhirParseService = new FhirParseService();

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
@@ -2,10 +2,11 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
 
 import java.io.IOException;
@@ -169,6 +170,8 @@ public class MedicationStatementMapperTest {
     @BeforeEach
     public void setUp() throws IOException {
         when(mockRandomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        when(mockRandomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
+
         codeableConceptCdMapper = new CodeableConceptCdMapper();
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
         Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);
@@ -231,11 +234,14 @@ public class MedicationStatementMapperTest {
         var expected = ResourceTestFileUtils.getFileContent(OUTPUT_XML_WITH_PRESCRIBE_BASED_ON);
 
         when(mockRandomIdGeneratorService.createNewId()).thenReturn("123");
+        when(mockRandomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn("456");
+
+
         var inputAuthorise1 = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_PLAN_ACUTE_PRESCRIPTION);
         var parsedMedicationRequest1 = new FhirParseService().parseResource(inputAuthorise1, MedicationRequest.class);
         medicationStatementMapper.mapMedicationRequestToMedicationStatement(parsedMedicationRequest1);
 
-        when(mockRandomIdGeneratorService.createNewId()).thenReturn("456", "456", "123", "789");
+        when(mockRandomIdGeneratorService.createNewId()).thenReturn("456", "123", "789");
         var inputWithBasedOn = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_ORDER_BASED_ON);
         var parsedMedicationRequestWithBasedOn = new FhirParseService().parseResource(inputWithBasedOn, MedicationRequest.class);
         String outputMessageWithBasedOn =
@@ -365,12 +371,13 @@ public class MedicationStatementMapperTest {
 
     @ParameterizedTest
     @MethodSource("resourceFilesWithMedicationStatement")
-    public void When_MappingMedicationRequest_WithMedicationStateMent_Expect_PrescribingAgencyMappedToSupplyType(
+    public void When_MappingMedicationRequest_WithMedicationStatement_Expect_PrescribingAgencyMappedToSupplyType(
         String inputJson, String outputXml) throws IOException {
 
         var expected = ResourceTestFileUtils.getFileContent(outputXml);
 
         when(mockRandomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+
         codeableConceptCdMapper = new CodeableConceptCdMapper();
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE_WITH_MEDICATION_STATEMENTS);
         Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapperTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildReference;
@@ -195,7 +197,9 @@ public class ObservationStatementMapperTest {
 
     @BeforeEach
     public void setUp() {
-        when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        lenient().when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        lenient().when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
+
         when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         messageContext = new MessageContext(randomIdGeneratorService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationToNarrativeStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationToNarrativeStatementMapperTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildReference;
@@ -66,6 +67,8 @@ public class ObservationToNarrativeStatementMapperTest {
     @BeforeEach
     public void setUp() {
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
+
         messageContext = new MessageContext(randomIdGeneratorService);
         messageContext.initialize(new Bundle());
         observationToNarrativeStatementMapper = new ObservationToNarrativeStatementMapper(messageContext, new ParticipantMapper());

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingServiceTest.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.gp2gp.gpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -79,8 +80,12 @@ class StructuredRecordMappingServiceTest {
     @Test
     void When_GettingExternalAttachments_Expect_AllDocumentReferenceResourcesAreMapped() {
         when(randomIdGeneratorService.createNewId()).thenReturn(
-            NEW_DOC_MANIFEST_ID_1, NEW_DOC_MANIFEST_ID_1,
-            NEW_DOC_MANIFEST_ID_2, NEW_DOC_MANIFEST_ID_2
+            NEW_DOC_MANIFEST_ID_1,
+            NEW_DOC_MANIFEST_ID_2
+        );
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(
+            NEW_DOC_MANIFEST_ID_1,
+            NEW_DOC_MANIFEST_ID_2
         );
         when(gp2gpConfiguration.getLargeAttachmentThreshold()).thenReturn(LARGE_MESSAGE_THRESHOLD);
         when(supportedContentTypes.isContentTypeSupported(any())).thenReturn(true);
@@ -109,6 +114,7 @@ class StructuredRecordMappingServiceTest {
     @Test
     void When_GettingExternalAttachment_WithWrongContentType_Expect_AbsentAttachmentMapped() {
         when(randomIdGeneratorService.createNewId()).thenReturn(NEW_DOC_MANIFEST_ID_1);
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(NEW_DOC_MANIFEST_ID_1);
         when(gp2gpConfiguration.getLargeAttachmentThreshold()).thenReturn(LARGE_MESSAGE_THRESHOLD);
 
         var mappedExternalAttachments = getMappedAbsentAttachments(
@@ -125,6 +131,7 @@ class StructuredRecordMappingServiceTest {
     @Test
     public void When_GettingExternalAttachment_WithTitleAndNoUrl_Expect_AbsentAttachmentMapped() {
         when(randomIdGeneratorService.createNewId()).thenReturn(NEW_DOC_MANIFEST_ID_1);
+        when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(NEW_DOC_MANIFEST_ID_1);
         when(gp2gpConfiguration.getLargeAttachmentThreshold()).thenReturn(LARGE_MESSAGE_THRESHOLD);
 
         var mappedExternalAttachments = getMappedAbsentAttachments(


### PR DESCRIPTION
## What

Updated the RandomIdGeneratorService and IdMapper to preserve UUIDs if a valid UUID is passed in.
Added additional testing for these services
Update unit tests to add mocking for the additional method within RandomIdGeneratorService

## Why

Currently the GP2GP Sending adaptor does not preserve the UUIDs for resources when mapping from Json to XML.  Valid GUID's should be preserved for resources where possible.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
