### PR TITLE
NIAD-3088: GP2GP adaptor should support OIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* When mapping `ReferralRequest` supporting info and `DiagnosticReports`m NHS PMIP Report Numbers can also be provided 
+with the code system as a URN (`urn:oid:2.16.840.1.113883.2.1.4.5.5`).
+
 ## [2.0.5] - 2024-07-04
 
 ### Fixed

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -61,8 +61,9 @@ public class DiagnosticReportMapper {
     private static final String PREPENDED_TEXT_FOR_FILLING_DATE = "Filing Date: ";
     private static final String PREPENDED_TEXT_FOR_PARTICIPANTS = "Participants: ";
 
-    private static final String EXTENSION_ID_SYSTEM_ID = "2.16.840.1.113883.2.1.4.5.5";
+    private static final String PMIP_CODE_SYSTEM = "2.16.840.1.113883.2.1.4.5.5";
     private static final String COMMENT_NOTE = "37331000000100";
+    public static final String URN_OID_PREFIX = "urn:oid:";
 
     private final MessageContext messageContext;
     private final SpecimenMapper specimenMapper;
@@ -103,7 +104,7 @@ public class DiagnosticReportMapper {
 
     private String fetchExtensionId(List<Identifier> identifiers) {
         return identifiers.stream()
-            .filter(identifier -> EXTENSION_ID_SYSTEM_ID.equals(identifier.getSystem()))
+            .filter(DiagnosticReportMapper::isPMIPCodeSystem)
             .map(Identifier::getValue)
             .findFirst()
             .orElse(StringUtils.EMPTY);
@@ -254,7 +255,7 @@ public class DiagnosticReportMapper {
     }
 
     private void buildNarrativeStatementForMissingResults(DiagnosticReport diagnosticReport, StringBuilder reportLevelNarrativeStatements) {
-        if (reportLevelNarrativeStatements.length() == 0 && !diagnosticReport.hasResult()) {
+        if (reportLevelNarrativeStatements.isEmpty() && !diagnosticReport.hasResult()) {
             String narrativeStatementFromCodedDiagnosis = buildNarrativeStatementForDiagnosticReport(
                 diagnosticReport.getIssuedElement(), CommentType.AGGREGATE_COMMENT_SET.getCode(), "EMPTY REPORT"
             );
@@ -320,5 +321,11 @@ public class DiagnosticReportMapper {
         observations.stream()
             .map(Observation::getIdElement)
             .forEach(idMapper::markObservationAsMapped);
+    }
+
+    private static boolean isPMIPCodeSystem(Identifier identifier) {
+        return StringUtils
+            .removeStart(identifier.getSystem(), URN_OID_PREFIX)
+            .equals(PMIP_CODE_SYSTEM);
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/SupportingInfoResourceExtractor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/SupportingInfoResourceExtractor.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.BaseDateTimeType;
 import org.hl7.fhir.dstu3.model.DocumentReference;
 import org.hl7.fhir.dstu3.model.DiagnosticReport;
@@ -17,154 +18,196 @@ import org.hl7.fhir.dstu3.model.ReferralRequest;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.MessageContext;
 
 public class SupportingInfoResourceExtractor {
-    private static final String CODE_SYSTEM = "2.16.840.1.113883.2.1.4.5.5";
+    private static final String PMIP_CODE_SYSTEM = "2.16.840.1.113883.2.1.4.5.5";
+    public static final String URN_OID_PREFIX = "urn:oid:";
 
     public static String extractDocumentReference(MessageContext messageContext, Reference reference) {
-        DocumentReference documentReference = messageContext
+        var documentReferenceOptional = messageContext
                 .getInputBundleHolder()
                 .getResource(reference.getReferenceElement())
-                .map(DocumentReference.class::cast)
-                .get();
+                .map(DocumentReference.class::cast);
 
-        StringBuilder stringBuilder = new StringBuilder();
+        if (documentReferenceOptional.isEmpty()) {
+            return "";
+        }
+
+        var stringBuilder = new StringBuilder();
         stringBuilder.append("{ Document:");
 
+        var documentReference = documentReferenceOptional.get();
+
         if (documentReference.hasCreated()) {
-            stringBuilder.append(" " + formatDateUsingDayPrecision(documentReference.getCreatedElement()));
+            stringBuilder
+                .append(" ")
+                .append(formatDateUsingDayPrecision(documentReference.getCreatedElement()));
         } else {
-            stringBuilder.append(" " + formatDateUsingDayPrecision(documentReference.getIndexedElement()));
+            stringBuilder
+                .append(" ")
+                .append(formatDateUsingDayPrecision(documentReference.getIndexedElement()));
         }
 
-        if (documentReference.hasType()) {
-            if (documentReference.getType().hasText()) {
-                stringBuilder.append(" " + documentReference.getType().getText());
-            } else if (documentReference.getType().hasCoding()) {
-                CodeableConceptMappingUtils.extractTextOrCoding(
-                    documentReference.getType()).ifPresent(docType -> stringBuilder.append(" " + docType)
-                );
-            }
-        }
+        CodeableConceptMappingUtils.extractTextOrCoding(documentReference.getType()).ifPresent(
+            code -> stringBuilder
+                .append(" ")
+                .append(code)
+        );
 
         if (documentReference.hasDescription()) {
-            stringBuilder.append(" " + documentReference.getDescription());
+            stringBuilder
+                .append(" ")
+                .append(documentReference.getDescription());
         }
-
         stringBuilder.append(" }");
 
         return stringBuilder.toString();
     }
 
     public static String extractObservation(MessageContext messageContext, Reference reference) {
-        Observation observation = messageContext
+        var observationOptional = messageContext
                 .getInputBundleHolder()
                 .getResource(reference.getReferenceElement())
-                .map(Observation.class::cast)
-                .get();
+                .map(Observation.class::cast);
 
-        StringBuilder stringBuilder = new StringBuilder();
+        if (observationOptional.isEmpty()) {
+            return "";
+        }
+
+        var stringBuilder = new StringBuilder();
         stringBuilder.append("{ Observation:");
 
+        var observation = observationOptional.get();
+
         if (observation.hasEffectiveDateTimeType()) {
-            stringBuilder.append(" " + formatDateUsingDayPrecision(observation.getEffectiveDateTimeType()));
+            stringBuilder
+                .append(" ")
+                .append(formatDateUsingDayPrecision(observation.getEffectiveDateTimeType()));
         } else if (observation.hasEffectivePeriod()) {
             if (observation.getEffectivePeriod().hasStart()) {
-                stringBuilder.append(" " + formatDateUsingDayPrecision(observation.getEffectivePeriod().getStartElement()));
+                stringBuilder
+                    .append(" ")
+                    .append(formatDateUsingDayPrecision(observation.getEffectivePeriod().getStartElement()));
             }
         }
 
-        CodeableConceptMappingUtils.extractTextOrCoding(observation.getCode()).ifPresent(code -> stringBuilder.append(" " + code));
+        CodeableConceptMappingUtils.extractTextOrCoding(observation.getCode()).ifPresent(
+            code -> stringBuilder
+                .append(" ")
+                .append(code)
+        );
+
         stringBuilder.append(" }");
 
         return stringBuilder.toString();
     }
 
     public static String extractReferralRequest(MessageContext messageContext, Reference reference) {
-        ReferralRequest referralRequest = messageContext
+        var referralRequestOptional = messageContext
                 .getInputBundleHolder()
                 .getResource(reference.getReferenceElement())
-                .map(ReferralRequest.class::cast)
-                .get();
+                .map(ReferralRequest.class::cast);
 
-        StringBuilder stringBuilder = new StringBuilder();
+        if (referralRequestOptional.isEmpty()) {
+            return "";
+        }
+
+        var stringBuilder = new StringBuilder();
         stringBuilder.append("{ Referral:");
 
+        var referralRequest = referralRequestOptional.get();
+
         if (referralRequest.hasAuthoredOn()) {
-            stringBuilder.append(" " + formatDateUsingDayPrecision(referralRequest.getAuthoredOnElement()));
+            stringBuilder
+                .append(" ")
+                .append(formatDateUsingDayPrecision(referralRequest.getAuthoredOnElement()));
         }
 
         if (referralRequest.hasReasonCode()) {
-            CodeableConceptMappingUtils.extractTextOrCoding(referralRequest.getReasonCode().get(0)).ifPresent(reasonCode ->
-                stringBuilder.append(" " + reasonCode)
+            CodeableConceptMappingUtils.extractTextOrCoding(referralRequest.getReasonCode().get(0)).ifPresent(
+                    reasonCode -> stringBuilder
+                        .append(" ")
+                        .append(reasonCode)
             );
         }
-
         stringBuilder.append(" }");
 
         return stringBuilder.toString();
     }
 
     public static String extractDiagnosticReport(MessageContext messageContext, Reference reference) {
-        DiagnosticReport diagnosticReport = messageContext
+        var diagnosticReportOptional = messageContext
                 .getInputBundleHolder()
                 .getResource(reference.getReferenceElement())
-                .map(DiagnosticReport.class::cast)
-                .get();
+                .map(DiagnosticReport.class::cast);
 
-        StringBuilder stringBuilder = new StringBuilder();
+        if (diagnosticReportOptional.isEmpty()) {
+            return "";
+        }
+
+        var stringBuilder = new StringBuilder();
         stringBuilder.append("{ Pathology Report:");
 
+        var diagnosticReport = diagnosticReportOptional.get();
+
         if (diagnosticReport.hasIssued()) {
-            stringBuilder.append(" " + formatDateUsingDayPrecision(diagnosticReport.getIssuedElement()));
+            stringBuilder
+                .append(" ")
+                .append(formatDateUsingDayPrecision(diagnosticReport.getIssuedElement()));
         }
 
         Optional<Identifier> identifier = diagnosticReport
-                .getIdentifier()
-                .stream()
-                .filter(d -> d.getSystem().equals(CODE_SYSTEM))
-                .findFirst();
+            .getIdentifier()
+            .stream()
+            .filter(SupportingInfoResourceExtractor::isPMIPCodeSystem)
+            .findFirst();
 
-        if (identifier.isPresent()) {
-            stringBuilder.append(" " + identifier.get().getValue());
-        }
-
+        identifier.ifPresent(
+            value -> stringBuilder
+                .append(" ")
+                .append(value.getValue())
+        );
         stringBuilder.append(" }");
 
         return stringBuilder.toString();
     }
 
     public static String extractMedicationRequest(MessageContext messageContext, Reference reference) {
-        MedicationRequest medicationRequest = messageContext
+        var medicationRequestOptional = messageContext
                 .getInputBundleHolder()
                 .getResource(reference.getReferenceElement())
-                .map(MedicationRequest.class::cast)
-                .get();
+                .map(MedicationRequest.class::cast);
 
-        StringBuilder stringBuilder = new StringBuilder();
+        if (medicationRequestOptional.isEmpty()) {
+            return "";
+        }
+
+        var stringBuilder = new StringBuilder();
         stringBuilder.append("{ Medication:");
+
+        var medicationRequest = medicationRequestOptional.get();
 
         if (medicationRequest.hasDispenseRequest()) {
             if (medicationRequest.getDispenseRequest().getValidityPeriod().hasStart()) {
-                stringBuilder.append(" "
-                        + formatDateUsingDayPrecision(
-                        medicationRequest
-                                .getDispenseRequest()
-                                .getValidityPeriod()
-                                .getStartElement()));
+                stringBuilder
+                    .append(" ")
+                    .append(
+                        formatDateUsingDayPrecision(
+                            medicationRequest.getDispenseRequest().getValidityPeriod().getStartElement()
+                        )
+                    );
             }
         }
 
         if (medicationRequest.hasMedicationReference()) {
-            Medication medication = messageContext
-                    .getInputBundleHolder()
-                    .getResource(medicationRequest.getMedicationReference().getReferenceElement())
-                    .map(Medication.class::cast)
-                    .get();
-
-            CodeableConceptMappingUtils.extractTextOrCoding(medication.getCode()).ifPresent(code ->
-                stringBuilder.append(" " + code)
-            );
+            messageContext
+                .getInputBundleHolder()
+                .getResource(medicationRequest.getMedicationReference().getReferenceElement())
+                .map(Medication.class::cast)
+                .flatMap(medication -> CodeableConceptMappingUtils.extractTextOrCoding(medication.getCode()))
+                .ifPresent(code -> stringBuilder
+                    .append(" ")
+                    .append(code)
+                );
         }
-
         stringBuilder.append(" }");
 
         return stringBuilder.toString();
@@ -173,5 +216,11 @@ public class SupportingInfoResourceExtractor {
     private static String formatDateUsingDayPrecision(BaseDateTimeType baseDateTimeType) {
         baseDateTimeType.setPrecision(TemporalPrecisionEnum.DAY);
         return DateFormatUtil.toTextFormat(baseDateTimeType);
+    }
+
+    private static boolean isPMIPCodeSystem(Identifier identifier) {
+        return StringUtils
+            .removeStart(identifier.getSystem(), URN_OID_PREFIX)
+            .equals(PMIP_CODE_SYSTEM);
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -61,6 +61,7 @@ public class DiagnosticReportMapperTest {
     private static final String INPUT_JSON_CODED_DIAGNOSIS = "diagnostic-report-with-coded-diagnosis.json";
     private static final String INPUT_JSON_MULTIPLE_CODED_DIAGNOSIS = "diagnostic-report-with-multiple-coded-diagnosis.json";
     private static final String INPUT_JSON_EXTENSION_ID = "diagnostic-report-with-extension-id.json";
+    private static final String INPUT_JSON_URN_OID_EXTENSION_ID = "diagnostic-report-with-urn-oid-extension-id.json";
 
     private static final String OUTPUT_XML_REQUIRED_DATA = "diagnostic-report-with-required-data.xml";
     private static final String OUTPUT_XML_STATUS_NARRATIVE = "diagnostic-report-with-status-narrative.xml";
@@ -117,7 +118,7 @@ public class DiagnosticReportMapperTest {
 
     @ParameterizedTest
     @MethodSource("resourceFileParams")
-    public void When_MappingDiagnosticReportJson_Expect_CompoundStatementXmlOutput(String inputJson, String outputXml) throws IOException {
+    public void When_MappingDiagnosticReportJson_Expect_CompoundStatementXmlOutput(String inputJson, String outputXml) {
         final CharSequence expectedOutputMessage = ResourceTestFileUtils.getFileContent(TEST_FILE_DIRECTORY + outputXml);
         final String jsonInput = ResourceTestFileUtils.getFileContent(TEST_FILE_DIRECTORY + inputJson);
         final DiagnosticReport diagnosticReport = new FhirParseService().parseResource(jsonInput, DiagnosticReport.class);
@@ -144,7 +145,8 @@ public class DiagnosticReportMapperTest {
             Arguments.of(INPUT_JSON_CONCLUSION, OUTPUT_XML_CONCLUSION),
             Arguments.of(INPUT_JSON_CODED_DIAGNOSIS, OUTPUT_XML_CODED_DIAGNOSIS),
             Arguments.of(INPUT_JSON_MULTIPLE_CODED_DIAGNOSIS, OUTPUT_XML_MULTIPLE_CODED_DIAGNOSIS),
-            Arguments.of(INPUT_JSON_EXTENSION_ID, OUTPUT_XML_EXTENSION_ID)
+            Arguments.of(INPUT_JSON_EXTENSION_ID, OUTPUT_XML_EXTENSION_ID),
+            Arguments.of(INPUT_JSON_URN_OID_EXTENSION_ID, OUTPUT_XML_EXTENSION_ID)
         );
     }
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/SupportingInfoResourceExtractorTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/SupportingInfoResourceExtractorTest.java
@@ -1,0 +1,381 @@
+package uk.nhs.adaptors.gp2gp.utils;
+
+import lombok.SneakyThrows;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.DateTimeType;
+import org.hl7.fhir.dstu3.model.DiagnosticReport;
+import org.hl7.fhir.dstu3.model.DocumentReference;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Identifier;
+import org.hl7.fhir.dstu3.model.Medication;
+import org.hl7.fhir.dstu3.model.MedicationRequest;
+import org.hl7.fhir.dstu3.model.Observation;
+import org.hl7.fhir.dstu3.model.Period;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.ReferralRequest;
+import org.hl7.fhir.dstu3.model.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.adaptors.gp2gp.ehr.mapper.InputBundle;
+import uk.nhs.adaptors.gp2gp.ehr.mapper.MessageContext;
+import uk.nhs.adaptors.gp2gp.ehr.utils.SupportingInfoResourceExtractor;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SupportingInfoResourceExtractorTest {
+    public static final CodeableConcept CODEABLE_CONCEPT_WITH_TEXT_AND_CODING_DISPLAY = new CodeableConcept()
+        .setText("CodeText")
+        .addCoding(
+            new Coding().setDisplay("DisplayText")
+        );
+
+    public static final CodeableConcept CODEABLE_CONCEPT_WITH_CODING_DISPLAY_ONLY = new CodeableConcept()
+        .addCoding(
+            new Coding().setDisplay("DisplayText")
+        );
+
+    public static final IdType REFERENCE_ID = new IdType("TestReference");
+    public static final Reference REFERENCE = new Reference(REFERENCE_ID);
+
+    @Mock
+    private InputBundle inputBundle;
+
+    @Mock
+    private MessageContext messageContext;
+
+    private final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+
+    @BeforeEach
+    public void setup() {
+        when(messageContext.getInputBundleHolder()).thenReturn(inputBundle);
+    }
+
+    @Test
+    public void When_ExtractDocumentReferenceAndMessageContextDoesNotContainDocumentReference_Expect_StringIsEmpty() {
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.empty());
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDocumentReference(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEmpty();
+    }
+
+    @Test
+    public void When_ExtractDocumentReferenceAndDocumentReferenceHasCreated_Expect_StringContainsCreated() {
+        final var resource = (Resource) new DocumentReference()
+            .setCreated(getDate("2010-01-01"))
+            .setIndexed(getDate("2020-02-02"));
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDocumentReference(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Document: 2010-01-01 }");
+    }
+
+    @Test
+    public void When_ExtractDocumentReferenceAndDocumentReferenceHasIndexedWithNoCreated_Expect_StringContainsCreated() {
+        final var resource = (Resource) new DocumentReference()
+            .setIndexed(getDate("2020-02-02"));
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDocumentReference(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Document: 2020-02-02 }");
+    }
+
+    @Test
+    public void When_ExtractDocumentReferenceAndDocumentReferenceHasTypeText_Expect_StringContainsText() {
+        final var resource = (Resource) new DocumentReference()
+            .setCreated(getDate("2010-01-01"))
+            .setType(CODEABLE_CONCEPT_WITH_TEXT_AND_CODING_DISPLAY);
+
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDocumentReference(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Document: 2010-01-01 CodeText }");
+    }
+
+    @Test
+    public void When_ExtractDocumentReferenceAndDocumentReferenceHasTypeWithDisplayOnly_Expect_StringContainsDisplay() {
+        final var resource = (Resource) new DocumentReference()
+            .setCreated(getDate("2010-01-01"))
+            .setType(CODEABLE_CONCEPT_WITH_CODING_DISPLAY_ONLY);
+
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDocumentReference(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Document: 2010-01-01 DisplayText }");
+    }
+
+    @Test
+    public void When_ExtractDocumentReferenceAndDocumentReferenceHasDescription_Expect_StringContainsDescription() {
+        final var resource = (Resource) new DocumentReference()
+            .setCreated(getDate("2010-01-01"))
+            .setType(new CodeableConcept().setText("TypeText"))
+            .setDescription("Description");
+
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDocumentReference(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Document: 2010-01-01 TypeText Description }");
+    }
+
+    @Test
+    public void When_ExtractObservationAndMessageContextDoesNotContainObservation_Expect_StringIsEmpty() {
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.empty());
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractObservation(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEmpty();
+    }
+
+    @Test
+    public void When_ExtractObservationAndObservationHasEffectiveDateTimeType_Expect_StringContainsEffectiveDate() {
+        final var resource = (Resource) new Observation()
+            .setEffective(new DateTimeType("2010-01-01"));
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractObservation(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Observation: 2010-01-01 }");
+    }
+
+    @Test
+    public void When_ExtractObservationAndObservationHasEffectivePeriodWithStart_Expect_StringContainsStartDate() {
+        final var resource = (Resource) new Observation()
+            .setEffective(new Period().setStart(getDate("2020-02-02")));
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractObservation(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Observation: 2020-02-02 }");
+    }
+
+    @Test
+    public void When_ExtractObservationAndObservationHasCodeText_Expect_StringContainsCodeText() {
+        final var resource = (Resource) new Observation()
+            .setEffective(new DateTimeType("2010-01-01"))
+            .setCode(CODEABLE_CONCEPT_WITH_TEXT_AND_CODING_DISPLAY);
+
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractObservation(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Observation: 2010-01-01 CodeText }");
+    }
+
+    @Test
+    public void When_ExtractObservationAndObservationHasCodeWithDisplayOnly_Expect_StringContainsDisplay() {
+        final var resource = (Resource) new Observation()
+            .setEffective(new DateTimeType("2010-01-01"))
+            .setCode(CODEABLE_CONCEPT_WITH_CODING_DISPLAY_ONLY);
+
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractObservation(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Observation: 2010-01-01 DisplayText }");
+    }
+
+    @Test
+    public void When_ExtractReferralRequestAndMessageContextDoesNotContainReferralRequest_Expect_StringIsEmpty() {
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.empty());
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractReferralRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEmpty();
+    }
+
+    @Test
+    public void When_ExtractReferralRequestAndReferralHasAuthoredOn_Expect_StringContainsAuthoredOnDate() {
+        final var resource = (Resource) new ReferralRequest()
+            .setAuthoredOn(getDate("2010-01-01"));
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractReferralRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Referral: 2010-01-01 }");
+    }
+
+    @Test
+    public void When_ExtractReferralRequestAndReferralHasReasonCodeText_Expect_StringContainsCodeText() {
+        final var resource = (Resource) new ReferralRequest()
+            .setAuthoredOn(getDate("2010-01-01"))
+            .addReasonCode(CODEABLE_CONCEPT_WITH_TEXT_AND_CODING_DISPLAY);
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractReferralRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Referral: 2010-01-01 CodeText }");
+    }
+
+    @Test
+    public void When_ExtractReferralRequestAndReferralHasReasonCodeWithDisplayOnly_Expect_StringContainsDisplay() {
+        final var resource = (Resource) new ReferralRequest()
+            .setAuthoredOn(getDate("2010-01-01"))
+            .addReasonCode(CODEABLE_CONCEPT_WITH_CODING_DISPLAY_ONLY);
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractReferralRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Referral: 2010-01-01 DisplayText }");
+    }
+
+    @Test
+    public void When_ExtractDiagnosticReportAndMessageContextDoesNotContainDiagnosticReport_Expect_StringIsEmpty() {
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.empty());
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDiagnosticReport(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEmpty();
+    }
+
+    @Test
+    public void When_ExtractDiagnosticReportAndReportHasIssued_Expect_StringContainsIssued() {
+        final var resource = (Resource) new DiagnosticReport()
+            .setIssued(getDate("2010-01-01"));
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDiagnosticReport(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Pathology Report: 2010-01-01 }");
+    }
+
+    @Test
+    public void When_ExtractDiagnosticReportAndReportHasPMIPIdentifierSystem_Expect_StringContainsIdentifierValue() {
+        final var resource = (Resource) new DiagnosticReport()
+            .setIssued(getDate("2010-01-01"))
+            .setIdentifier(
+                List.of(
+                    new Identifier()
+                        .setSystem("2.16.840.1.113883.2.1.4.5.5")
+                        .setValue("IdentifierValue")
+                )
+            );
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDiagnosticReport(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Pathology Report: 2010-01-01 IdentifierValue }");
+    }
+
+    @Test
+    public void When_ExtractDiagnosticReportAndReportHasPMIPIdentifierSystemWithOID_Expect_StringContainsIdentifierValue() {
+        final var resource = (Resource) new DiagnosticReport()
+            .setIssued(getDate("2010-01-01"))
+            .setIdentifier(
+                List.of(
+                    new Identifier()
+                        .setSystem("urn:oid:2.16.840.1.113883.2.1.4.5.5")
+                        .setValue("IdentifierValue")
+                )
+            );
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDiagnosticReport(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Pathology Report: 2010-01-01 IdentifierValue }");
+    }
+
+    @Test
+    public void When_ExtractDiagnosticReportAndReportHasNonPMIPIdentifierSystem_Expect_StringDoesNotContainIdentifierValue() {
+        final var resource = (Resource) new DiagnosticReport()
+            .setIssued(getDate("2010-01-01"))
+            .setIdentifier(
+                List.of(
+                    new Identifier()
+                        .setSystem("1.2.3.4.5")
+                        .setValue("IdentifierValue")
+                )
+            );
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractDiagnosticReport(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Pathology Report: 2010-01-01 }");
+    }
+
+    @Test
+    public void When_ExtractMedicationRequestAndMessageContextDoesNotContainMedicationRequest_Expect_StringIsEmpty() {
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.empty());
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractMedicationRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEmpty();
+    }
+
+    @Test
+    public void When_ExtractMedicationRequestAndRequestHasDispenseValidityPeriodStart_Expect_StringContainsStartDate() {
+        final var resource = (Resource) new MedicationRequest()
+            .setDispenseRequest(
+                new MedicationRequest.MedicationRequestDispenseRequestComponent()
+                    .setValidityPeriod(new Period().setStart(getDate("2010-01-01")))
+            );
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractMedicationRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Medication: 2010-01-01 }");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void When_ExtractMedicationRequestAndRequestHasMedicationReferenceWithCodeText_Expect_StringContainsCodeText() {
+        final var dispenseRequest = new MedicationRequest.MedicationRequestDispenseRequestComponent()
+            .setValidityPeriod(
+                new Period()
+                    .setStart(getDate("2010-01-01"))
+            );
+        final var resource = (Resource) new MedicationRequest()
+            .setDispenseRequest(dispenseRequest)
+            .setMedication(REFERENCE);
+        final var medication = (Resource) new Medication()
+            .setCode(CODEABLE_CONCEPT_WITH_TEXT_AND_CODING_DISPLAY);
+
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource), Optional.of(medication));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractMedicationRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Medication: 2010-01-01 CodeText }");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void When_ExtractMedicationRequestAndRequestHasMedicationReferenceWithCodeDisplayOnly_Expect_StringContainsDisplay() {
+        final var dispenseRequest = new MedicationRequest.MedicationRequestDispenseRequestComponent()
+            .setValidityPeriod(
+                new Period()
+                    .setStart(getDate("2010-01-01"))
+            );
+        final var resource = (Resource) new MedicationRequest()
+            .setDispenseRequest(dispenseRequest)
+            .setMedication(REFERENCE);
+        final var medication = (Resource) new Medication()
+            .setCode(CODEABLE_CONCEPT_WITH_CODING_DISPLAY_ONLY);
+
+        when(inputBundle.getResource(REFERENCE_ID)).thenReturn(Optional.of(resource), Optional.of(medication));
+
+        final var supportingInfo = SupportingInfoResourceExtractor.extractMedicationRequest(messageContext, REFERENCE);
+
+        assertThat(supportingInfo).isEqualTo("{ Medication: 2010-01-01 DisplayText }");
+    }
+
+    @SneakyThrows
+    private Date getDate(String dateString) {
+        return new Date(simpleDateFormat.parse(dateString).getTime());
+    }
+}
+

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-urn-oid-extension-id.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-urn-oid-extension-id.json
@@ -1,0 +1,45 @@
+{
+        "resourceType": "DiagnosticReport",
+        "id": "2723501E-0803-4D02-BDD2-F943CFDBEDC3",
+        "meta": {
+            "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+            ]
+        },
+        "identifier": [
+            {
+                "system": "https://EMISWeb/A82038",
+                "value": "DAED5527198545D9993EC5FF51F368282723501E08034D02BDD2F943CFDBEDC3"
+            },
+            {
+                "system": "urn:oid:2.16.840.1.113883.2.1.4.5.5",
+                "value": "CHM0100950302121100G,03.0999008001"
+            }
+        ],
+        "status": "unknown",
+        "category": {
+            "coding": [
+                {
+                    "system": "http://hl7.org/fhir/v2/0074",
+                    "code": "PAT",
+                    "display": "Pathology (gross & histopath, not surgical)"
+                }
+            ]
+        },
+        "code": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "721981007",
+                    "display": "Diagnostic studies report"
+                }
+            ]
+        },
+        "subject": {
+            "reference": "Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+        },
+        "context": {
+            "reference": "Encounter/BFAFEAD6-5C17-406D-B064-8BE7CC8CCD2B"
+        },
+        "issued": "2010-02-25T15:41:00+00:00"
+}


### PR DESCRIPTION
## What

Unit Tests added for SupportingInfoResourceAdaptor.
Updated SupportingInfoResourceAdaptor to handle NHS PMIP Report Numbers code systems prefixed with `urn:oid:`

Unit Test added for DiagnosticReportMapper
Updated DiagnosticReportMapper to handle NHS PMIP Report Numbers code systems prefixed with `urn:oid:`

Fixed `'Optional.get()' without 'isPresent()'` issues in SupportingInfoResourceExtractor.  Whereas previously this would throw an exception, the only place these methods are consumed are designed to handle an empty string being returned.  Have fixed this by returning an empty string if the resource is not found in the mapping context.

Fixed  `String concatenation as argument to 'StringBuilder.append()'` issues in SupportingInfoResourceExtractor by using StringBuilder correctly.

## Why

As the PS Adaptor now produces code systems with the format `urn:oid:1.2.3.4.5.6` the GP2GP adaptor should also support when codes are received in this format

Also:
`SupportingInfoResourceExtractor` contains multiple warnings for the following code issues:

* 'Optional.get()' without 'isPresent()' check 
* String concatenation as argument to 'StringBuilder.append()' call

These should be fixed so as to reduce errors and improve efficiency.

## Type of change

Please delete options that are not relevant.

- [x]  New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](https://github.com/NHSDigital/integration-adaptor-gp2gp/pull/CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users