### PR TITLE
NIAD-3005: Handle NOPAT `Meta.Security` for `AllergyIntolerance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* When mapping `AllergyIntolerances` which contain a `NOPAT` `meta.security` tag the resultant XML for that resource
+will contain a `NOPAT` `confidentialityCode` element.
+
 ## [2.0.6] - 2024-07-29
 
 ### Added

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/AllergyStructureTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/AllergyStructureTemplateParameters.java
@@ -18,4 +18,5 @@ public class AllergyStructureTemplateParameters {
     private String code;
     private String author;
     private String performer;
+    private String confidentialityCode;
 }

--- a/service/src/main/resources/templates/ehr_allergy_structure_template.mustache
+++ b/service/src/main/resources/templates/ehr_allergy_structure_template.mustache
@@ -2,6 +2,9 @@
     <CompoundStatement classCode="CATEGORY" moodCode="EVN">
         <id root="{{allergyStructureId}}"/>
         {{{categoryCode}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         <statusCode code="COMPLETE"/>
         <effectiveTime>
             {{{effectiveTime}}}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
@@ -245,7 +245,7 @@ public class AllergyStructureMapperTest {
 
     @Test
     public void When_ConfidentialityServiceReturnsConfidentialityCode_Expect_MessageContainsConfidentialityCode() {
-        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile("/ehr/mapper/allergy/example-allergy-intolerance-resource-1.json");
+        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile(INPUT_JSON_WITH_OPTIONAL_TEXT_FIELDS);
         when(confidentialityService.generateConfidentialityCode(allergyIntolerance))
             .thenReturn(Optional.of(CONFIDENTIALITY_CODE));
 
@@ -255,8 +255,8 @@ public class AllergyStructureMapperTest {
     }
 
     @Test
-    public void When_ConfidentialityServiceReturnsEmptyOptionalExpect_MessageDoesNotContainConfidentialityCode() {
-        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile("/ehr/mapper/allergy/example-allergy-intolerance-resource-1.json");
+    public void When_ConfidentialityServiceReturnsEmptyOptional_Expect_MessageDoesNotContainConfidentialityCode() {
+        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile(INPUT_JSON_WITH_OPTIONAL_TEXT_FIELDS);
 
         final var message = allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(allergyIntolerance);
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
@@ -12,12 +12,15 @@ import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildReference;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.hl7.fhir.dstu3.model.AllergyIntolerance;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.ResourceType;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
@@ -113,8 +117,6 @@ public class AllergyStructureMapperTest {
         + "expected-output-allergy-structure-without-endDate.xml";
     private static final String OUTPUT_XML_USES_NO_ASSERTED_DATE = TEST_FILE_DIRECTORY
             + "expected-output-allergy-structure-without-assertedDate.xml";
-    private static final String OUTPUT_XML_USES_RECORDER_AS_PERFORMER = TEST_FILE_DIRECTORY
-        + "expected-output-allergy-structure-17.xml";
     private static final String OUTPUT_XML_USES_NO_AUTHOR_OR_PERFORMER = TEST_FILE_DIRECTORY
             + "expected-output-allergy-structure-18.xml";
     private static final String OUTPUT_XML_USES_RECORDER_AS_PERFORMER_RELATED_PERSON_ASSERTER = TEST_FILE_DIRECTORY
@@ -127,13 +129,23 @@ public class AllergyStructureMapperTest {
         + "expected-output-allergy-structure-22.xml";
     private static final String COMMON_ID = "6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73";
 
+    private static final String CONFIDENTIALITY_CODE = """
+        <confidentialityCode
+            code="NOPAT"
+            codeSystem="2.16.840.1.113883.4.642.3.47"
+            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+        />""";
+
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
     @Mock
     private CodeableConceptCdMapper codeableConceptCdMapper;
+    @Mock
+    private ConfidentialityService confidentialityService;
 
     private AllergyStructureMapper allergyStructureMapper;
     private MessageContext messageContext;
+
 
     private static Stream<Arguments> resourceFileParams() {
         return Stream.of(
@@ -167,30 +179,6 @@ public class AllergyStructureMapperTest {
         );
     }
 
-    private static Stream<Arguments> resourceInvalidFileParams() {
-        return Stream.of(
-            Arguments.of(INPUT_JSON_WITH_NO_CATEGORY),
-            Arguments.of(INPUT_JSON_WITH_UNSUPPORTED_CATEGORY)
-        );
-    }
-
-    @AfterEach
-    public void tearDown() {
-        messageContext.resetMessageContext();
-    }
-
-    @ParameterizedTest
-    @MethodSource("resourceFileParams")
-    public void When_MappingAllergyIntoleranceJson_Expect_AllergyStructureXmlOutput(String inputJson, String outputXml)
-        throws IOException {
-        CharSequence expectedOutputMessage = ResourceTestFileUtils.getFileContent(outputXml);
-        var jsonInput = ResourceTestFileUtils.getFileContent(inputJson);
-        AllergyIntolerance parsedAllergyIntolerance = new FhirParseService().parseResource(jsonInput, AllergyIntolerance.class);
-
-        String outputMessage = allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(parsedAllergyIntolerance);
-        assertThat(outputMessage).isEqualTo(expectedOutputMessage);
-    }
-
     @BeforeEach
     public void setUp() throws IOException {
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
@@ -201,12 +189,13 @@ public class AllergyStructureMapperTest {
         lenient().when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         lenient().when(codeableConceptCdMapper.mapCodeableConceptToCdForAllergy(any(CodeableConcept.class),
-            any(AllergyIntolerance.AllergyIntoleranceClinicalStatus.class)))
+                any(AllergyIntolerance.AllergyIntoleranceClinicalStatus.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         lenient().when(codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(any(CodeableConcept.class),
-            any(AllergyIntolerance.AllergyIntoleranceClinicalStatus.class)))
+                any(AllergyIntolerance.AllergyIntoleranceClinicalStatus.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
-
+        lenient().when(confidentialityService.generateConfidentialityCode(any()))
+            .thenReturn(Optional.empty());
 
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
         Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);
@@ -216,16 +205,67 @@ public class AllergyStructureMapperTest {
             .forEach(resourceType -> messageContext.getIdMapper().getOrNew(resourceType, buildIdType(resourceType, COMMON_ID)));
         List.of(ResourceType.Practitioner, ResourceType.Organization)
             .forEach(resourceType -> messageContext.getAgentDirectory().getAgentId(buildReference(resourceType, COMMON_ID)));
-        allergyStructureMapper = new AllergyStructureMapper(messageContext, codeableConceptCdMapper, new ParticipantMapper());
+        allergyStructureMapper = new AllergyStructureMapper(
+            messageContext,
+            codeableConceptCdMapper,
+            new ParticipantMapper(),
+            confidentialityService);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        messageContext.resetMessageContext();
+    }
+
+    private static Stream<Arguments> resourceInvalidFileParams() {
+        return Stream.of(
+            Arguments.of(INPUT_JSON_WITH_NO_CATEGORY),
+            Arguments.of(INPUT_JSON_WITH_UNSUPPORTED_CATEGORY)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("resourceFileParams")
+    public void When_MappingAllergyIntoleranceJson_Expect_AllergyStructureXmlOutput(String inputJson, String outputXml) {
+        final var expectedMessage = ResourceTestFileUtils.getFileContent(outputXml);
+        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile(inputJson);
+
+        String message = allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(allergyIntolerance);
+        assertThat(message).contains(expectedMessage);
     }
 
     @ParameterizedTest
     @MethodSource("resourceInvalidFileParams")
-    public void When_MappingInvalidAllergyIntoleranceJson_Expect_Exception(String inputJson) throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(inputJson);
-        AllergyIntolerance parsedAllergyIntolerance = new FhirParseService().parseResource(jsonInput, AllergyIntolerance.class);
+    public void When_MappingInvalidAllergyIntoleranceJson_Expect_Exception(String inputJson) {
+        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile(inputJson);
 
         assertThrows(EhrMapperException.class, ()
-            -> allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(parsedAllergyIntolerance));
+            -> allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(allergyIntolerance));
     }
+
+    @Test
+    public void When_ConfidentialityServiceReturnsConfidentialityCode_Expect_MessageContainsConfidentialityCode() {
+        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile("/ehr/mapper/allergy/example-allergy-intolerance-resource-1.json");
+        when(confidentialityService.generateConfidentialityCode(allergyIntolerance))
+            .thenReturn(Optional.of(CONFIDENTIALITY_CODE));
+
+        final var message = allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(allergyIntolerance);
+
+        assertThat(message).contains(CONFIDENTIALITY_CODE);
+    }
+
+    @Test
+    public void When_ConfidentialityServiceReturnsEmptyOptionalExpect_MessageDoesNotContainConfidentialityCode() {
+        final var allergyIntolerance = parseAllergyIntoleranceFromJsonFile("/ehr/mapper/allergy/example-allergy-intolerance-resource-1.json");
+
+        final var message = allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(allergyIntolerance);
+
+        assertThat(message).doesNotContain(CONFIDENTIALITY_CODE);
+    }
+
+    private static AllergyIntolerance parseAllergyIntoleranceFromJsonFile(String filepath) {
+        final var jsonInput = ResourceTestFileUtils.getFileContent(filepath);
+        return new FhirParseService().parseResource(jsonInput, AllergyIntolerance.class);
+    }
+
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.service.TimestampService;
@@ -27,7 +28,6 @@ import uk.nhs.adaptors.gp2gp.gpc.GetGpcStructuredTaskDefinition;
 import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.util.stream.Stream;
 
@@ -83,7 +83,6 @@ public class EhrExtractMapperComponentTest {
     private static final String TEST_DATE_TIME = "2020-01-01T01:01:01.01Z";
 
     private static GetGpcStructuredTaskDefinition getGpcStructuredTaskDefinition;
-    private ParticipantMapper participantMapper;
 
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
@@ -91,6 +90,8 @@ public class EhrExtractMapperComponentTest {
     private TimestampService timestampService;
     @Mock
     private CodeableConceptCdMapper codeableConceptCdMapper;
+    @Mock
+    private ConfidentialityService confidentialityService;
 
     private NonConsultationResourceMapper nonConsultationResourceMapper;
     private EhrExtractMapper ehrExtractMapper;
@@ -159,7 +160,7 @@ public class EhrExtractMapperComponentTest {
 
         EncounterComponentsMapper encounterComponentsMapper = new EncounterComponentsMapper(
             messageContext,
-            new AllergyStructureMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new AllergyStructureMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new BloodPressureMapper(
                 messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
                 codeableConceptCdMapper, new ParticipantMapper()),
@@ -211,7 +212,7 @@ public class EhrExtractMapperComponentTest {
 
     @ParameterizedTest
     @MethodSource("testData")
-    public void When_MappingProperJsonRequestBody_Expect_ProperXmlOutput(String input, String expected) throws IOException {
+    public void When_MappingProperJsonRequestBody_Expect_ProperXmlOutput(String input, String expected) {
         String expectedJsonToXmlContent = ResourceTestFileUtils.getFileContent(OUTPUT_PATH + expected);
         String inputJsonFileContent = ResourceTestFileUtils.getFileContent(INPUT_PATH + input);
         Bundle bundle = new FhirParseService().parseResource(inputJsonFileContent, Bundle.class);
@@ -240,7 +241,7 @@ public class EhrExtractMapperComponentTest {
     }
 
     @Test
-    public void When_MappingJsonBody_Expect_OnlyOneConsultationResource() throws IOException {
+    public void When_MappingJsonBody_Expect_OnlyOneConsultationResource() {
         String expectedJsonToXmlContent = ResourceTestFileUtils.getFileContent(OUTPUT_PATH + EXPECTED_XML_FOR_ONE_CONSULTATION_RESOURCE);
         String inputJsonFileContent = ResourceTestFileUtils.getFileContent(ONE_CONSULTATION_RESOURCE_BUNDLE);
         Bundle bundle = new FhirParseService().parseResource(inputJsonFileContent, Bundle.class);
@@ -254,7 +255,7 @@ public class EhrExtractMapperComponentTest {
     }
 
     @Test
-    public void When_TransformingResourceToEhrComp_Expect_NoDuplicateMappings() throws IOException {
+    public void When_TransformingResourceToEhrComp_Expect_NoDuplicateMappings() {
         String bundle = ResourceTestFileUtils.getFileContent(DUPLICATE_RESOURCE_BUNDLE);
         Bundle parsedBundle = new FhirParseService().parseResource(bundle, Bundle.class);
         messageContext.initialize(parsedBundle);


### PR DESCRIPTION
## What

Update AllergyStructureMapper to add confidentialityCode based on the results of the ConfidentialityService when passed the resource.
Add tests for this functionality.
Update AllergyStructureTemplateParameters to include confidentialityCode. 
Update Moustache template for AllergyStructure to include confidentialityCode if present. 
Add Mocks for ConfidentialityCode to derived tests using the AllergyStructureMapper.
Address existing issues with checkstyle / spotbugs for modified files.

## Why

When an `AllergyIntolerance` resource contains a `meta.security` `NOPAT` value, as below:

```json
{
  "meta": {
    "security": [{
      "system":"http://hl7.org/fhir/v3/ActCode",
      "code":"NOPAT",
      "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
    }]
  }
}
```

Then the produced mapped XML should contain the following `confidentialityCode`:

```xml
<confidentialityCode
    code="NOPAT"
    codeSystem="2.16.840.1.113883.4.642.3.47"
    displayName="no disclosure to patient, family or caregivers without attending provider's authorization" 
/>
```

This is needed as part of the requirement for Redaction Changes.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
