### PR TITLE
Add NOPAT security to AllergyIntolerance in Wiremock stub

### DIFF
--- a/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
@@ -469,6 +469,14 @@
                     "profile":
                     [
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+                    ],
+                    "security":
+                    [
+                        {
+                            "system":"http://hl7.org/fhir/v3/ActCode",
+                            "code":"NOPAT",
+                            "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+                        }
                     ]
                 },
                 "identifier":


### PR DESCRIPTION
## Why

Helps testing NOPAT functionality with Incumbents

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
