### PR TITLE
Don't fail Actions Workflow when no mutation testing is performed

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -152,6 +152,9 @@ pitest {
 	// git feature limits analysis to contents of PR only
 	features = ["+GIT(from[HEAD~1])"]
 
+	// PRs which don't introduce any production code changes, shouldn't fail the Mutation Testing Actions Workflow
+        failWhenNoMutations = false
+
 	mutators = ['STRONGER', 'EXTENDED_ALL']
 
 	threads = project.getGradle().getStartParameter().getMaxWorkerCount()


### PR DESCRIPTION
## Why

`pitest-github` gradle task will fail by default if no mutation testing is performed.

This will occur when a PR is raised which doesn't change any production code. e.g. docs, tests only etc.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
