### PR TITLE
Niad-2840: Identifies no acknowledgment after 8 Days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added a scheduled delay checker to update EhrExtract to "Integration Failure" state if sentAt exceeds 192 hours and no acknowledgment is received. 
+
 ### Added
 
 * When mapping `AllergyIntolerances` which contain a `NOPAT` `meta.security` tag the resultant XML for that resource

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
@@ -17,6 +17,7 @@ import uk.nhs.adaptors.gp2gp.testcontainers.ActiveMQExtension;
 import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -34,7 +35,6 @@ public class EhrContinueTest {
     private final RandomIdGeneratorService randomIdGeneratorService = new RandomIdGeneratorService();
 
     private static final String CONTINUE_ACKNOWLEDGEMENT = "Continue Acknowledgement";
-
 
     @Autowired
     private EhrExtractRequestHandler ehrExtractRequestHandler;
@@ -59,7 +59,7 @@ public class EhrContinueTest {
             }));
 
         var ehrExtract = ehrExtractStatusRepository.findByConversationId(ehrExtractStatus.getConversationId());
-        assertThat(ehrExtract.get().getEhrContinue().getReceived()).isNotNull();
+        assertNotNull(ehrExtract.get().getEhrContinue().getReceived());
     }
 
     @Test
@@ -82,8 +82,8 @@ public class EhrContinueTest {
         Exception exception = assertThrows(NonExistingInteractionIdException.class,
             () -> ehrExtractRequestHandler.handleContinue(conversationId, CONTINUE_ACKNOWLEDGEMENT));
 
-        assertThat(exception.getMessage()).isEqualTo("Received a Continue message that is not recognised with conversation_id: '"
-            + conversationId + "'");
+        assertThat(exception.getMessage()).isEqualTo("Received a Continue message that is not recognised with conversation_id: "
+            + conversationId);
         verify(taskDispatcher, never()).createTask(any());
     }
 

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrContinueTest.java
@@ -12,7 +12,7 @@ import uk.nhs.adaptors.gp2gp.common.task.TaskDispatcher;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 import uk.nhs.adaptors.gp2gp.ehr.request.EhrExtractRequestHandler;
 import uk.nhs.adaptors.gp2gp.mhs.InvalidInboundMessageException;
-import uk.nhs.adaptors.gp2gp.mhs.exception.NonExistingInteractionIdException;
+import uk.nhs.adaptors.gp2gp.mhs.exception.UnrecognisedInteractionIdException;
 import uk.nhs.adaptors.gp2gp.testcontainers.ActiveMQExtension;
 import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
 
@@ -79,10 +79,10 @@ public class EhrContinueTest {
     public void When_EhrContinueThrowsException_Expect_EhrExtractStatusNotUpdated() {
         String conversationId = randomIdGeneratorService.createNewId();
 
-        Exception exception = assertThrows(NonExistingInteractionIdException.class,
-            () -> ehrExtractRequestHandler.handleContinue(conversationId, CONTINUE_ACKNOWLEDGEMENT));
+        Exception exception = assertThrows(UnrecognisedInteractionIdException.class,
+                                           () -> ehrExtractRequestHandler.handleContinue(conversationId, CONTINUE_ACKNOWLEDGEMENT));
 
-        assertThat(exception.getMessage()).isEqualTo("Received a Continue message that is not recognised with conversation_id: "
+        assertThat(exception.getMessage()).isEqualTo("Received an unrecognized Continue message with conversation_id: "
             + conversationId);
         verify(taskDispatcher, never()).createTask(any());
     }

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceIT.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceIT.java
@@ -47,7 +47,7 @@ import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
 @ExtendWith({MongoDBExtension.class})
 @DirtiesContext
 @SpringBootTest
-public class EhrExtractStatusServiceTest {
+public class EhrExtractStatusServiceIT {
     private static final Instant NOW = Instant.now();
     private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
     private static final int DEFAULT_CONTENT_LENGTH = 244;

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/InboundMessageHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/InboundMessageHandler.java
@@ -16,7 +16,7 @@ import uk.nhs.adaptors.gp2gp.common.service.ProcessFailureHandlingService;
 import uk.nhs.adaptors.gp2gp.common.service.XPathService;
 import uk.nhs.adaptors.gp2gp.ehr.request.EhrExtractRequestHandler;
 import uk.nhs.adaptors.gp2gp.mhs.exception.MessageOutOfOrderException;
-import uk.nhs.adaptors.gp2gp.mhs.exception.NonExistingInteractionIdException;
+import uk.nhs.adaptors.gp2gp.mhs.exception.UnrecognisedInteractionIdException;
 import uk.nhs.adaptors.gp2gp.mhs.exception.UnsupportedInteractionException;
 
 import jakarta.jms.JMSException;
@@ -63,7 +63,7 @@ public class InboundMessageHandler {
             }
             return true;
 
-        } catch (MessageOutOfOrderException | NonExistingInteractionIdException | UnsupportedInteractionException e) {
+        } catch (MessageOutOfOrderException | UnrecognisedInteractionIdException | UnsupportedInteractionException e) {
             LOGGER.error("An error occurred while handing MHS inbound message id: {}", messageID, e);
             return false;
         } catch (DataAccessResourceFailureException e) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/NonExistingInteractionIdException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/NonExistingInteractionIdException.java
@@ -2,7 +2,6 @@ package uk.nhs.adaptors.gp2gp.mhs.exception;
 
 public class NonExistingInteractionIdException extends RuntimeException {
     public NonExistingInteractionIdException(String messageType, String conversationId) {
-        super("Received a " + messageType + " message that is not recognised with conversation_id: '" + conversationId
-            + "'");
+        super("Received a " + messageType + " message that is not recognised with conversation_id: " + conversationId);
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/NonExistingInteractionIdException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/NonExistingInteractionIdException.java
@@ -1,7 +1,0 @@
-package uk.nhs.adaptors.gp2gp.mhs.exception;
-
-public class NonExistingInteractionIdException extends RuntimeException {
-    public NonExistingInteractionIdException(String messageType, String conversationId) {
-        super("Received a " + messageType + " message that is not recognised with conversation_id: " + conversationId);
-    }
-}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/UnrecognisedInteractionIdException.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/mhs/exception/UnrecognisedInteractionIdException.java
@@ -1,0 +1,10 @@
+package uk.nhs.adaptors.gp2gp.mhs.exception;
+
+public class UnrecognisedInteractionIdException extends RuntimeException {
+
+    private static final String EXCEPTION_MESSAGE = "Received an unrecognized %s message with conversation_id: %s";
+
+    public UnrecognisedInteractionIdException(String messageType, String conversationId) {
+        super(EXCEPTION_MESSAGE.formatted(messageType, conversationId));
+    }
+}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class EhrExtractStatusServiceUnitTest {
+class EhrExtractStatusServiceTest {
 
     public static final int NINE_DAYS = 9;
     public static final int EIGHT_DAYS = 8;

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
@@ -82,8 +82,6 @@ class EhrExtractStatusServiceUnitTest {
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
         String conversationId = "11111";
         Instant currentInstant = Instant.now();
-        Instant nineDaysAgo = currentInstant.minus(Duration.ofDays(NINE_DAYS));
-        Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder().updatedAt(nineDaysAgo).build());
 
         doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
         doReturn(false).when(ehrExtractStatusServiceSpy).hasFinalAckBeenReceived(conversationId);
@@ -110,7 +108,6 @@ class EhrExtractStatusServiceUnitTest {
         Instant currentInstant = Instant.now();
         Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
         Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder().updatedAt(eightDaysAgo).build());
-
 
         doReturn(ehrExtractStatus).when(ehrExtractStatusRepository).findByConversationId(conversationId);
         when(ack.getErrors()).thenReturn(null);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class EhrExtractStatusServiceUnitTest {
 
+    public static final int NINE_DAYS = 9;
+    public static final int EIGHT_DAYS = 8;
     @Mock
     private MongoTemplate mongoTemplate;
 
@@ -37,7 +39,7 @@ class EhrExtractStatusServiceUnitTest {
     private TimestampService timestampService;
 
     @Mock
-    EhrExtractStatus.EhrReceivedAcknowledgement ack;
+    private EhrExtractStatus.EhrReceivedAcknowledgement ack;
 
     @InjectMocks
     private EhrExtractStatusService ehrExtractStatusService;
@@ -52,7 +54,7 @@ class EhrExtractStatusServiceUnitTest {
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
         String conversationId = "11111";
         Instant currentInstant = Instant.now();
-        Instant nineDaysAgo = currentInstant.minus(Duration.ofDays(9));
+        Instant nineDaysAgo = currentInstant.minus(Duration.ofDays(NINE_DAYS));
         Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder().updatedAt(nineDaysAgo).build());
 
         doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
@@ -76,7 +78,7 @@ class EhrExtractStatusServiceUnitTest {
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
         String conversationId = "11111";
         Instant currentInstant = Instant.now();
-        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(8));
+        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
         Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder().updatedAt(eightDaysAgo).build());
 
         doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
@@ -29,6 +29,7 @@ class EhrExtractStatusServiceUnitTest {
 
     public static final int NINE_DAYS = 9;
     public static final int EIGHT_DAYS = 8;
+    public static final String ERROR_CODE = "04";
     @Mock
     private MongoTemplate mongoTemplate;
 
@@ -68,7 +69,7 @@ class EhrExtractStatusServiceUnitTest {
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
         verify(ehrExtractStatusServiceSpy).updateEhrExtractStatusError(conversationId,
-                                                                       "04",
+                                                                       ERROR_CODE,
                                                                        "The acknowledgement has been received after 8 days",
                                                                        ehrExtractStatusServiceSpy.getClass().getSimpleName());
     }
@@ -92,7 +93,7 @@ class EhrExtractStatusServiceUnitTest {
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
         verify(ehrExtractStatusServiceSpy, never()).updateEhrExtractStatusError(conversationId,
-                                                                       "04",
+                                                                                ERROR_CODE,
                                                                        "The acknowledgement has been received after 8 days",
                                                                        ehrExtractStatusServiceSpy.getClass().getSimpleName());
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceUnitTest.java
@@ -17,7 +17,9 @@ import java.time.Duration;
 
 import java.time.Instant;
 import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -118,6 +120,23 @@ class EhrExtractStatusServiceUnitTest {
                                                                                 ERROR_CODE,
                                                                                 ERROR_MESSAGE,
                                                                        ehrExtractStatusServiceSpy.getClass().getSimpleName());
+    }
+
+    @Test
+    void doesNotUpdateEhrExtractStatusWhenEhrContinueIsPresent() {
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        String conversationId = "11111";
+
+        Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder()
+                                                                      .ehrExtractCorePending(
+            EhrExtractStatus.EhrExtractCorePending.builder().sentAt(Instant.now()).taskId("22222").build())
+                                                                      .ehrContinue(EhrExtractStatus.EhrContinue.builder().build())
+                                                                      .build());
+        doReturn(ehrExtractStatus).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+
+        var ehrExtractStatusResult = ehrExtractStatusServiceSpy.updateEhrExtractStatusContinue(conversationId);
+
+        assertFalse(ehrExtractStatusResult.isPresent());
     }
 
 }


### PR DESCRIPTION
## What

Setting the final ack for EhrExtract has been limited by a deadline of 8 days

## Why

There has been a deadline of 8 days set between receiving documents and the final ACK. If the deadline is exceeded the ACK will be ignored. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
