### PR TITLE
NIAD-3137: EMIS rejects flat consultation structure from GP2GP Adaptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* When mapping consultations which are "flat" (i.e., they contain a `TOPIC` without a `CATEGORY`) we now wrap the 
+  resource into a virtual `CATEGORY`.
 * Added a scheduled delay checker to update EhrExtract to "Integration Failure" state if sentAt exceeds 8 days and no acknowledgment is received. 
 
 ### Added

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
@@ -418,7 +418,7 @@ public class EncounterComponentsMapper {
 
         var params = CompoundStatementParameters.builder()
             .nested(nested)
-            .id(messageContext.getIdMapper().newId(ResourceType.List, topicList.getIdElement()))
+            .id(messageContext.getIdMapper().getOrNew(ResourceType.List, topicList.getIdElement()))
             .classCode(classCode)
             .compoundStatementCode(compoundStatementCode)
             .statusCode(COMPLETE_CODE)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
@@ -128,28 +128,73 @@ public class EncounterComponentsMapper {
     }
 
     private String mapTopicListComponents(ListResource topicList) {
-        return mapCategorizedResources(topicList) + mapListResourceToComponents(topicList);
+        return String.join(
+            StringUtils.EMPTY,
+            mapCategorizedResources(topicList),
+            mapContainedResources(topicList),
+            mapUncategorizedResources(topicList)
+        );
     }
 
     private String mapCategorizedResources(ListResource topicList) {
         return topicList.getEntry().stream()
             .map(EncounterComponentsMapper::getReferenceElement)
-            .filter(reference -> reference.getValue().matches(LIST_REFERENCE_PATTERN))
+            .filter(reference -> reference
+                .getValue()
+                .matches(LIST_REFERENCE_PATTERN)
+            )
             .map(this::getRequiredResource)
-            .filter(resource -> ResourceType.List.equals(resource.getResourceType()))
             .map(ListResource.class::cast)
-            .filter(listResource -> CodeableConceptMappingUtils.hasCode(listResource.getCode(), List.of(CATEGORY_LIST_CODE)))
             .map(this::mapCategoryListToComponent)
             .collect(Collectors.joining());
     }
 
     private String mapCategoryListToComponent(ListResource categoryList) {
+        if (!CodeableConceptMappingUtils.hasCode(categoryList.getCode(), List.of(CATEGORY_LIST_CODE))) {
+            throw new EhrMapperException(
+                    "Unexpected list %s referenced in Consultation, expected list to be coded as Category (EHR) or be a container"
+                            .formatted(categoryList.getId())
+            );
+        }
+
         return buildCompoundStatement(
             categoryList,
             CATEGORY.getCode(),
             prepareCdForCategory(categoryList),
             true,
             mapListResourceToComponents(categoryList)
+        );
+    }
+
+    private String mapContainedResources(ListResource topicList) {
+        return topicList.getEntry().stream()
+            .filter(entry -> getReferenceElement(entry)
+                .getValue()
+                .matches(CONTAINED_RESOURCE_REFERENCE_PATTERN)
+            )
+            .map(this::mapItemToComponent)
+            .flatMap(Optional::stream)
+            .collect(Collectors.joining());
+    }
+
+    private String mapUncategorizedResources(ListResource topicList) {
+        var components = topicList.getEntry().stream()
+            .map(EncounterComponentsMapper::getReferenceElement)
+            .filter(reference ->
+                !reference.getValue().matches(LIST_REFERENCE_PATTERN)
+                && !reference.getValue().matches(CONTAINED_RESOURCE_REFERENCE_PATTERN)
+            )
+            .map(this::getRequiredResource)
+            .map(this::mapConsultationListResourceToComponent)
+            .flatMap(Optional::stream)
+            .collect(Collectors.joining());
+
+        return buildCompoundStatement(
+            topicList,
+            CATEGORY.getCode(),
+            codeableConceptCdMapper.getCdForCategory(),
+            true,
+            components
         );
     }
 
@@ -192,11 +237,11 @@ public class EncounterComponentsMapper {
         }
 
         if (isIgnoredResourceType(resource.getResourceType())) {
-            LOGGER.info(String.format("Resource of type: %s has been ignored", resource.getResourceType()));
+            LOGGER.info("Resource of type: {} has been ignored", resource.getResourceType());
             return Optional.empty();
         }
 
-        throw new EhrMapperException("Unsupported resource in consultation list: " + resource.getId());
+        throw new EhrMapperException("Unsupported resource in consultation list: %s".formatted(resource.getId()));
     }
 
     public Optional<String> mapResourceToComponent(Resource resource) {
@@ -325,14 +370,7 @@ public class EncounterComponentsMapper {
         var matcher = pattern.matcher(fullReference.getValue());
 
         if (!matcher.find()) {
-            var listResource = (ListResource) getRequiredResource(fullReference);
-
-            if (CodeableConceptMappingUtils.hasCode(listResource.getCode(), List.of(CATEGORY_LIST_CODE))) {
-                return Optional.empty();
-            }
-
-            throw new EhrMapperException("Unexpected list " + fullReference
-                + " referenced in Consultation, expected list to be coded as Category (EHR) or be a container");
+            return Optional.empty();
         }
 
         var listId = matcher.group(1);
@@ -380,7 +418,7 @@ public class EncounterComponentsMapper {
 
         var params = CompoundStatementParameters.builder()
             .nested(nested)
-            .id(messageContext.getIdMapper().getOrNew(ResourceType.List, topicList.getIdElement()))
+            .id(messageContext.getIdMapper().newId(ResourceType.List, topicList.getIdElement()))
             .classCode(classCode)
             .compoundStatementCode(compoundStatementCode)
             .statusCode(COMPLETE_CODE)

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
 
@@ -124,6 +125,9 @@ public class EncounterComponentsMapperTest {
                 "bloodPressureCode1", "bloodPressureCode2", "bloodPressureCode3"
             ))
         ))).thenReturn(true);
+        lenient()
+            .when(codeableConceptCdMapper.getCdForCategory())
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
         messageContext = new MessageContext(randomIdGeneratorService);
 
         ParticipantMapper participantMapper = new ParticipantMapper();

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-1.xml
@@ -86,32 +86,44 @@
 
             </CompoundStatement>
         </component>
-
-        <component typeCode="COMP">
-            <ObservationStatement classCode="OBS" moodCode="EVN">
-                <id root="394559384658936"/>
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936" />
                 <code nullFlavor="UNK">
                     <originalText>Mocked code</originalText>
                 </code>
-                <statusCode code="COMPLETE"/>
+                <statusCode code="COMPLETE" />
                 <effectiveTime>
-                    <center value="20100630055900"/>
+                    <low value="20100113152000" />
+                    <high value="20100113162000" />
                 </effectiveTime>
-                <availabilityTime value="20100630055900"/>
-                <pertinentInformation typeCode="PERT">
-                    <sequenceNumber value="+1"/>
-                    <pertinentAnnotation classCode="OBS" moodCode="EVN">
-                        <text>Primary Source: true immunization note</text>
-                    </pertinentAnnotation>
-                </pertinentInformation>
-                <Participant typeCode="PRF" contextControlCode="OP">
-                    <agentRef classCode="AGNT">
+                <availabilityTime value="20100123140354" />
+                <component typeCode="COMP">
+                    <ObservationStatement classCode="OBS" moodCode="EVN">
                         <id root="394559384658936"/>
-                    </agentRef>
-                </Participant>
-            </ObservationStatement>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center value="20100630055900"/>
+                        </effectiveTime>
+                        <availabilityTime value="20100630055900"/>
+                        <pertinentInformation typeCode="PERT">
+                            <sequenceNumber value="+1"/>
+                            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                <text>Primary Source: true immunization note</text>
+                            </pertinentAnnotation>
+                        </pertinentInformation>
+                        <Participant typeCode="PRF" contextControlCode="OP">
+                            <agentRef classCode="AGNT">
+                                <id root="394559384658936"/>
+                            </agentRef>
+                        </Participant>
+                    </ObservationStatement>
+                </component>
+            </CompoundStatement>
         </component>
-
     </CompoundStatement>
 </component>
 

--- a/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-17-topic-no-categories.xml
+++ b/service/src/test/resources/ehr/mapper/encountercomponents/expected-components-17-topic-no-categories.xml
@@ -10,19 +10,32 @@
             <high value="20100113162000"/>
         </effectiveTime>
         <availabilityTime value="20100113152000"/>
-
-        <component typeCode="COMP">
-            <PlanStatement classCode="OBS" moodCode="INT">
-                <id root="394559384658936"/>
+        <component typeCode="COMP" contextConductionInd="true">
+            <CompoundStatement classCode="CATEGORY" moodCode="EVN">
+                <id root="394559384658936" />
                 <code nullFlavor="UNK">
                     <originalText>Mocked code</originalText>
                 </code>
-                <statusCode code="COMPLETE"/>
+                <statusCode code="COMPLETE" />
                 <effectiveTime>
-                    <center nullFlavor="UNK"/>
+                    <low value="20100113152000" />
+                    <high value="20100113162000" />
                 </effectiveTime>
-                <availabilityTime value="20100113152950"/>
-            </PlanStatement>
+                <availabilityTime value="20100113152000" />
+                <component typeCode="COMP">
+                    <PlanStatement classCode="OBS" moodCode="INT">
+                        <id root="394559384658936"/>
+                        <code nullFlavor="UNK">
+                            <originalText>Mocked code</originalText>
+                        </code>
+                        <statusCode code="COMPLETE"/>
+                        <effectiveTime>
+                            <center nullFlavor="UNK"/>
+                        </effectiveTime>
+                        <availabilityTime value="20100113152950"/>
+                    </PlanStatement>
+                </component>
+            </CompoundStatement>
         </component>
     </CompoundStatement>
 </component>


### PR DESCRIPTION


## What

* Update test files for EncounterComponentsMapperTest to now deal with cases where a virtual category is added for topics without a category. 
* Add functionality to EncounterComponentsMapper to now deal with cases where a virtual category is added for topics without a category. 
* Refactor EncounterComponentsMapper for readability. 

## Why

When attempting to transfer a patient containing a "flat" consultation (where there is a "TOPIC" but with no "CATEGORY") then EMIS reject the patient transfer as they _"expect all TOPIC's to contain a CATEGORY"_.

To avoid the transfer failing, we should create a "virtual" category to contain the resources when translating.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
