### PR TITLE
NIAD-3147 - Populate `confidentialityCode` HL7v3 element when `meta.security` with value `NOPAT` is present within `Condition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ will contain a `NOPAT` `confidentialityCode` element.
   will contain a `NOPAT` `confidentialityCode` element.
 * When mapping a `TestResult`, `TestGroupHeader` or `FilingComment` which contains a `NOPAT` `meta.security` tag the resultant XML 
   for that resource will contain a `NOPAT` `confidentialityCode` element.
-* When mapping a `LinkSet` which contains a `NOPAT` `meta.security` tag the resultant XML for that resource
+* When mapping a `Condition` which contains a `NOPAT` `meta.security` tag the resultant XML for that resource
   will contain a `NOPAT` `confidentialityCode` element.
 
 ## [2.0.6] - 2024-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ will contain a `NOPAT` `confidentialityCode` element.
   will contain a `NOPAT` `confidentialityCode` element.
 * When mapping a `TestResult`, `TestGroupHeader` or `FilingComment` which contains a `NOPAT` `meta.security` tag the resultant XML 
   for that resource will contain a `NOPAT` `confidentialityCode` element.
+* When mapping a `LinkSet` which contains a `NOPAT` `meta.security` tag the resultant XML for that resource
+  will contain a `NOPAT` `confidentialityCode` element.
 
 ## [2.0.6] - 2024-07-29
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapper.java
@@ -21,6 +21,7 @@ import com.github.mustachejava.Mustache;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.ConditionLinkSetMapperParameters;
@@ -56,6 +57,7 @@ public class ConditionLinkSetMapper {
     private final RandomIdGeneratorService randomIdGeneratorService;
     private final CodeableConceptCdMapper codeableConceptCdMapper;
     private final ParticipantMapper participantMapper;
+    private final ConfidentialityService confidentialityService;
 
     public String mapConditionToLinkSet(Condition condition, boolean isNested) {
         if (!condition.hasAsserter()) {
@@ -70,6 +72,7 @@ public class ConditionLinkSetMapper {
         buildEffectiveTimeLow(condition).ifPresent(builder::effectiveTimeLow);
         buildEffectiveTimeHigh(condition).ifPresent(builder::effectiveTimeHigh);
         buildAvailabilityTime(condition).ifPresent(builder::availabilityTime);
+        builder.confidentialityCode(confidentialityService.generateConfidentialityCode(condition).orElse(null));
         builder.relatedClinicalContent(buildRelatedClinicalContent(condition));
 
         buildQualifier(condition).ifPresent(qualifier -> setQualifierProperties(builder, qualifier));

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/ConditionLinkSetMapperParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/ConditionLinkSetMapperParameters.java
@@ -21,6 +21,7 @@ public class ConditionLinkSetMapperParameters {
     private String effectiveTimeHigh;
     private String effectiveTimeLow;
     private String availabilityTime;
+    private String confidentialityCode;
     private List<String> relatedClinicalContent;
     private boolean generateObservationStatement;
     private String pertinentInfo;

--- a/service/src/main/resources/templates/ehr_link_set_template.mustache
+++ b/service/src/main/resources/templates/ehr_link_set_template.mustache
@@ -13,6 +13,9 @@
             {{#effectiveTimeHigh}}<high value="{{effectiveTimeHigh}}"/>{{/effectiveTimeHigh}}
         </effectiveTime>
         <availabilityTime value="{{availabilityTime}}" />
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#relatedClinicalContent}}
             <component typeCode="COMP">
                 <statementRef classCode="OBS" moodCode="EVN">

--- a/service/src/main/resources/templates/ehr_link_set_template.mustache
+++ b/service/src/main/resources/templates/ehr_link_set_template.mustache
@@ -52,6 +52,9 @@
             {{#effectiveTimeHigh}}<high value="{{effectiveTimeHigh}}"/>{{/effectiveTimeHigh}}
         </effectiveTime>
         <availabilityTime {{#observationStatementAvailabilityTime}}value="{{observationStatementAvailabilityTime}}"{{/observationStatementAvailabilityTime}}{{^observationStatementAvailabilityTime}}nullFlavor="UNK"{{/observationStatementAvailabilityTime}} />
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#pertinentInfo}}
         <pertinentInformation typeCode="PERT">
             <sequenceNumber value="+1" />

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
@@ -1,92 +1,104 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.ResourceType;
+import org.hl7.fhir.dstu3.model.Condition;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.IdType;
+
+import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
+import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
+import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
+import uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility;
+import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
+import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
+import uk.nhs.adaptors.gp2gp.utils.FileParsingUtility;
+import uk.nhs.adaptors.gp2gp.utils.XmlParsingUtility;
+
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import wiremock.org.custommonkey.xmlunit.XMLAssert;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+
+import java.util.stream.Stream;
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
-import static org.assertj.core.api.Assertions.assertThat;
 
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOSCRUB;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT;
 import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
 
-import java.io.IOException;
-import java.util.stream.Stream;
-
-import org.hl7.fhir.dstu3.model.IdType;
-import org.junit.jupiter.api.Test;
-
-import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
-import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
-import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
-import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
-import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
-import wiremock.org.custommonkey.xmlunit.XMLAssert;
-
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.CodeableConcept;
-import org.hl7.fhir.dstu3.model.Condition;
-import org.hl7.fhir.dstu3.model.Reference;
-import org.hl7.fhir.dstu3.model.ResourceType;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
-import org.xml.sax.SAXException;
-
 @ExtendWith(MockitoExtension.class)
-public class ConditionLinkSetMapperTest {
+class ConditionLinkSetMapperTest {
 
     private static final String CONDITION_ID = "7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB-PROB";
     private static final String GENERATED_ID = "50233a2f-128f-4b96-bdae-6207ed11a8ea";
     private static final String ALLERGY_ID = "230D3D37-99E3-450A-AE88-B5AB802B7137";
     private static final String IMMUNIZATION_ID = "C93659E1-1107-441C-BE25-C5EF4B7831D1";
-    private static final String CONDITION_FILE_LOCATIONS = "/ehr/mapper/condition/";
-    private static final String INPUT_JSON_BUNDLE = CONDITION_FILE_LOCATIONS + "fhir-bundle.json";
+    private static final String TEST_FILES_DIRECTORY = "/ehr/mapper/condition/";
 
-    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_OBSERVATION = CONDITION_FILE_LOCATIONS + "condition_all_included.json";
-    private static final String INPUT_JSON_NO_ACTUAL_PROBLEM = CONDITION_FILE_LOCATIONS + "condition_no_problem.json";
-    private static final String INPUT_JSON_NO_ACTUAL_PROBLEM_NO_DATE = CONDITION_FILE_LOCATIONS + "condition_no_problem_no_onsetdate.json";
-    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_CONDITION = CONDITION_FILE_LOCATIONS
-        + "condition_actual_problem_condition.json";
-    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_ALLERGY_INTOLERANCE = CONDITION_FILE_LOCATIONS
-        + "condition_actual_problem_allergy_intolerance.json";
-    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_IMMUNIZATION = CONDITION_FILE_LOCATIONS
-        + "condition_actual_problem_immunization.json";
-    private static final String INPUT_JSON_WITH_MAJOR_SIGNIFICANCE = CONDITION_FILE_LOCATIONS
-        + "condition_major_significance.json";
-    private static final String INPUT_JSON_WITH_MINOR_SIGNIFICANCE = CONDITION_FILE_LOCATIONS + "condition_all_included.json";
-    private static final String INPUT_JSON_NO_RELATED_CLINICAL_CONTENT = CONDITION_FILE_LOCATIONS
-        + "condition_no_related_clinical_content.json";
-    private static final String INPUT_JSON_MAP_TWO_RELATED_CLINICAL_CONTENT_IGNORE_ONE = CONDITION_FILE_LOCATIONS
-        + "condition_related_clinical_content_suppressed_linkage_references.json";
-    private static final String INPUT_JSON_MAP_TWO_RELATED_CLINICAL_CONTENT = CONDITION_FILE_LOCATIONS
-        + "condition_2_related_clinical_content.json";
-    private static final String INPUT_JSON_STATUS_ACTIVE = CONDITION_FILE_LOCATIONS + "condition_status_active.json";
-    private static final String INPUT_JSON_STATUS_INACTIVE = CONDITION_FILE_LOCATIONS + "condition_status_inactive.json";
-    private static final String INPUT_JSON_DATES_PRESENT = CONDITION_FILE_LOCATIONS + "condition_dates_present.json";
-    private static final String INPUT_JSON_DATES_NOT_PRESENT = CONDITION_FILE_LOCATIONS + "condition_dates_not_present.json";
-    private static final String INPUT_JSON_RELATED_CLINICAL_CONTENT_LIST_REFERENCE = CONDITION_FILE_LOCATIONS
-        + "condition_related_clinical_content_list_reference.json";
-    private static final String INPUT_JSON_RELATED_CLINICAL_CONTENT_NON_EXISTENT_REFERENCE = CONDITION_FILE_LOCATIONS
-        + "condition_related_clinical_content_non_existent_reference.json";
-    private static final String INPUT_JSON_ASSERTER_NOT_PRESENT = CONDITION_FILE_LOCATIONS + "condition_asserter_not_present.json";
-    private static final String INPUT_JSON_ASSERTER_NOT_PRACTITIONER = CONDITION_FILE_LOCATIONS
-        + "condition_asserter_not_practitioner.json";
-    private static final String INPUT_JSON_MISSING_CONDITION_CODE = CONDITION_FILE_LOCATIONS
-        + "condition_missing_code.json";
-    private static final String INPUT_JSON_SUPPRESSED_RELATED_MEDICATION_REQUEST = CONDITION_FILE_LOCATIONS
-        + "condition_suppressed_related_medication_request.json";
-    private static final String INPUT_JSON_RELATED_CLINICAL_CONTENT_ALLERGY = CONDITION_FILE_LOCATIONS
-        + "condition_related_clinical_content_allergy.json";
-    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_MEDICATION_REQUEST = CONDITION_FILE_LOCATIONS
-        + "condition_actual_problem_medication_request.json";
+    private static final String INPUT_JSON_BUNDLE = "fhir-bundle.json";
+    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_OBSERVATION = "condition_all_included.json";
+    private static final String INPUT_JSON_NO_ACTUAL_PROBLEM = "condition_no_problem.json";
+    private static final String INPUT_JSON_NO_ACTUAL_PROBLEM_NO_DATE = "condition_no_problem_no_onsetdate.json";
+    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_CONDITION = "condition_actual_problem_condition.json";
+    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_ALLERGY_INTOLERANCE =
+        "condition_actual_problem_allergy_intolerance.json";
+    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_IMMUNIZATION = "condition_actual_problem_immunization.json";
+    private static final String INPUT_JSON_WITH_MAJOR_SIGNIFICANCE = "condition_major_significance.json";
+    private static final String INPUT_JSON_WITH_MINOR_SIGNIFICANCE = "condition_all_included.json";
+    private static final String INPUT_JSON_NO_RELATED_CLINICAL_CONTENT = "condition_no_related_clinical_content.json";
+    private static final String INPUT_JSON_MAP_TWO_RELATED_CLINICAL_CONTENT_IGNORE_ONE =
+        "condition_related_clinical_content_suppressed_linkage_references.json";
+    private static final String INPUT_JSON_MAP_TWO_RELATED_CLINICAL_CONTENT = "condition_2_related_clinical_content.json";
+    private static final String INPUT_JSON_STATUS_ACTIVE = "condition_status_active.json";
+    private static final String INPUT_JSON_STATUS_INACTIVE = "condition_status_inactive.json";
+    private static final String INPUT_JSON_DATES_PRESENT = "condition_dates_present.json";
+    private static final String INPUT_JSON_DATES_NOT_PRESENT = "condition_dates_not_present.json";
+    private static final String INPUT_JSON_RELATED_CLINICAL_CONTENT_LIST_REFERENCE =
+        "condition_related_clinical_content_list_reference.json";
+    private static final String INPUT_JSON_RELATED_CLINICAL_CONTENT_NON_EXISTENT_REFERENCE =
+        "condition_related_clinical_content_non_existent_reference.json";
+    private static final String INPUT_JSON_ASSERTER_NOT_PRESENT = "condition_asserter_not_present.json";
+    private static final String INPUT_JSON_ASSERTER_NOT_PRACTITIONER = "condition_asserter_not_practitioner.json";
+    private static final String INPUT_JSON_MISSING_CONDITION_CODE = "condition_missing_code.json";
+    private static final String INPUT_JSON_SUPPRESSED_RELATED_MEDICATION_REQUEST =
+        "condition_suppressed_related_medication_request.json";
+    private static final String INPUT_JSON_RELATED_CLINICAL_CONTENT_ALLERGY = "condition_related_clinical_content_allergy.json";
+    private static final String INPUT_JSON_WITH_ACTUAL_PROBLEM_MEDICATION_REQUEST =
+        "condition_actual_problem_medication_request.json";
 
-    private static final String EXPECTED_OUTPUT_LINKSET = CONDITION_FILE_LOCATIONS + "expected_output_linkset_";
+    private static final String EXPECTED_OUTPUT_LINKSET = "expected_output_linkset_";
     private static final String OUTPUT_XML_WITH_IS_NESTED = EXPECTED_OUTPUT_LINKSET + "1.xml";
     private static final String OUTPUT_XML_WITHOUT_IS_NESTED = EXPECTED_OUTPUT_LINKSET + "2.xml";
     private static final String OUTPUT_XML_WITH_GENERATED_PROBLEM_IS_NESTED = EXPECTED_OUTPUT_LINKSET + "3.xml";
@@ -118,17 +130,18 @@ public class ConditionLinkSetMapperTest {
     private RandomIdGeneratorService randomIdGeneratorService;
     @Mock
     private CodeableConceptCdMapper codeableConceptCdMapper;
+    @Mock
+    private ConfidentialityService confidentialityService;
+    @Captor
+    private ArgumentCaptor<Condition> conditionArgumentCaptor;
 
     private InputBundle inputBundle;
     private ConditionLinkSetMapper conditionLinkSetMapper;
-    private FhirParseService fhirParseService;
 
     @BeforeEach
-    public void setUp() throws IOException {
-        fhirParseService = new FhirParseService();
-
-        var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
-        Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);
+    void setUp() throws IOException {
+        var bundleInput = ResourceTestFileUtils.getFileContent(TEST_FILES_DIRECTORY + INPUT_JSON_BUNDLE);
+        final Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);
         inputBundle = new InputBundle(bundle);
 
         lenient().when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
@@ -151,29 +164,29 @@ public class ConditionLinkSetMapperTest {
 
 
         conditionLinkSetMapper = new ConditionLinkSetMapper(messageContext, randomIdGeneratorService, codeableConceptCdMapper,
-            new ParticipantMapper());
+            new ParticipantMapper(), confidentialityService);
     }
 
     @AfterEach
-    public void tearDown() {
+    void afterEach() {
         messageContext.resetMessageContext();
     }
 
     @Test
-    public void When_MappingParsedConditionWithoutMappedAgent_Expect_Exception() throws IOException {
-        EhrMapperException propagatedException = new EhrMapperException("expected exception");
-        when(agentDirectory.getAgentId(any(Reference.class))).thenThrow(propagatedException);
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_STATUS_ACTIVE);
-        Condition condition = fhirParseService.parseResource(jsonInput, Condition.class);
+    void When_MappingParsedConditionWithoutMappedAgent_Expect_EhrMapperException() {
+        final EhrMapperException propagatedException = new EhrMapperException("expected exception");
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_STATUS_ACTIVE);
+
+        when(agentDirectory.getAgentId(any(Reference.class)))
+            .thenThrow(propagatedException);
 
         assertThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(condition, false))
             .isSameAs(propagatedException);
     }
 
     @Test
-    public void When_MappingParsedConditionWithoutAsserter_Expect_Exception() throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_ASSERTER_NOT_PRESENT);
-        Condition condition = fhirParseService.parseResource(jsonInput, Condition.class);
+    void When_MappingParsedConditionWithoutAsserter_Expect_EhrMapperException() {
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_ASSERTER_NOT_PRESENT);
 
         assertThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(condition, false))
             .isExactlyInstanceOf(EhrMapperException.class)
@@ -181,9 +194,8 @@ public class ConditionLinkSetMapperTest {
     }
 
     @Test
-    public void When_MappingParsedConditionWithAsserterNotPractitioner_Expect_Exception() throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_ASSERTER_NOT_PRACTITIONER);
-        Condition condition = fhirParseService.parseResource(jsonInput, Condition.class);
+    void When_MappingParsedConditionWithAsserterNotPractitioner_Expect_EhrMapperException() {
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_ASSERTER_NOT_PRACTITIONER);
 
         assertThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(condition, false))
             .isExactlyInstanceOf(EhrMapperException.class)
@@ -192,14 +204,100 @@ public class ConditionLinkSetMapperTest {
 
     @ParameterizedTest
     @MethodSource("testArguments")
-    public void When_MappingParsedConditionWithRealProblem_Expect_LinkSetXml(String conditionJson, String outputXml, boolean isNested)
-        throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(conditionJson);
-        var expectedOutput = ResourceTestFileUtils.getFileContent(outputXml);
-        Condition condition = fhirParseService.parseResource(jsonInput, Condition.class);
+    void When_MappingParsedCondition_With_RealProblem_Expect_LinkSetXml(String conditionJson, String outputXml, boolean isNested) {
+        final Condition condition = getConditionResourceFromJson(conditionJson);
+        final String expectedXml = getXmlStringFromFile(outputXml);
 
-        String outputMessage = conditionLinkSetMapper.mapConditionToLinkSet(condition, isNested);
-        assertThat(outputMessage).isEqualTo(expectedOutput);
+        final String actualXml = conditionLinkSetMapper.mapConditionToLinkSet(condition, isNested);
+
+        assertThat(actualXml).isEqualTo(expectedXml);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testObservationArguments")
+    void When_MappingParsedCondition_With_ActualProblemContentAndIsObservation_Expect_LinkSetXml(String conditionJson,
+                                                                                                 String outputXml, boolean isNested) {
+        final Condition condition = getConditionResourceFromJson(conditionJson);
+        final String expectedXml = getXmlStringFromFile(outputXml);
+
+        final String actualXml = conditionLinkSetMapper.mapConditionToLinkSet(condition, isNested);
+
+        assertThat(actualXml).isEqualTo(expectedXml);
+    }
+
+    @Test
+    void When_MappingParsedCondition_With_NoRelatedClinicalContent_Expect_LinkSetXml() {
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_NO_RELATED_CLINICAL_CONTENT);
+        final String expectedXml = getXmlStringFromFile(OUTPUT_XML_WITH_NO_RELATED_CLINICAL_CONTENT);
+
+        final String actualXml = conditionLinkSetMapper.mapConditionToLinkSet(condition, false);
+
+        assertThat(actualXml).isEqualTo(expectedXml);
+    }
+
+    @Test
+    void When_MappingParsedConditionWithNonExistentReferenceInRelatedClinicalContent_Expect_MapperException() {
+        final Condition parsedObservation = getConditionResourceFromJson(INPUT_JSON_RELATED_CLINICAL_CONTENT_NON_EXISTENT_REFERENCE);
+
+        when(messageContext.getInputBundleHolder()).thenReturn(inputBundle);
+
+        // TODO: workaround for NIAD-1409 should throw an exception but demonstrator include invalid references
+        assumeThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(parsedObservation, false))
+            .isExactlyInstanceOf(EhrMapperException.class)
+            .hasMessage("Could not resolve Condition Related Medical Content reference");
+    }
+
+    @Test
+    void When_MappingParsedConditionCodeIsMissing_Expect_MapperException() {
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_MISSING_CONDITION_CODE);
+
+        assertThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(condition, false))
+            .isExactlyInstanceOf(EhrMapperException.class)
+            .hasMessage("Condition code not present");
+    }
+
+    @Test
+    void When_MappingConditionWith_SuppressedMedReqAsRelatedClinicalContent_Expect_NoEntry() throws IOException, SAXException {
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_SUPPRESSED_RELATED_MEDICATION_REQUEST);
+        final String expectedXml = getXmlStringFromFile(OUTPUT_XML_SUPPRESSED_RELATED_MEDICATION_REQUEST);
+
+        final String actualXml = conditionLinkSetMapper.mapConditionToLinkSet(condition, false);
+
+        XMLAssert.assertXMLEqual(expectedXml, actualXml);
+    }
+
+    @Test
+    void When_MappingCondition_WithNopatMetaSecurity_Expect_ConfidentialityCodeWithinLinkset()
+        throws XPathExpressionException, IOException, ParserConfigurationException, SAXException {
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_SUPPRESSED_RELATED_MEDICATION_REQUEST);
+        final String xPath = "/component/LinkSet/" + ConfidentialityCodeUtility.getNopatConfidentialityCodeXpathSegment();
+
+        ConfidentialityCodeUtility.appendNopatSecurityToMetaForResource(condition);
+        when(confidentialityService.generateConfidentialityCode(conditionArgumentCaptor.capture()))
+            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
+
+        final String actualXml = conditionLinkSetMapper.mapConditionToLinkSet(condition, false);
+        final String conditionSecurityCode = ConfidentialityCodeUtility
+            .getSecurityCodeFromResource(conditionArgumentCaptor.getValue());
+
+        assertTrue(XmlParsingUtility.xpathMatchFound(actualXml, xPath));
+        assertThat(conditionSecurityCode).isEqualTo(NOPAT);
+    }
+
+    @Test
+    void When_MappingCondition_With_WithNoscrubMetaSecurity_Expect_ConfidentialityCodeNotPresent() {
+        final Condition condition = getConditionResourceFromJson(INPUT_JSON_SUPPRESSED_RELATED_MEDICATION_REQUEST);
+
+        ConfidentialityCodeUtility.appendNoscrubSecurityToMetaForResource(condition);
+        when(confidentialityService.generateConfidentialityCode(conditionArgumentCaptor.capture()))
+            .thenReturn(Optional.empty());
+
+        final String actualXml = conditionLinkSetMapper.mapConditionToLinkSet(condition, false);
+        final String conditionSecurityCode = ConfidentialityCodeUtility
+            .getSecurityCodeFromResource(conditionArgumentCaptor.getValue());
+
+        assertThat(actualXml).doesNotContainIgnoringCase(NOPAT_HL7_CONFIDENTIALITY_CODE);
+        assertThat(conditionSecurityCode).isEqualTo(NOSCRUB);
     }
 
     private static Stream<Arguments> testArguments() {
@@ -221,18 +319,6 @@ public class ConditionLinkSetMapperTest {
             Arguments.of(INPUT_JSON_RELATED_CLINICAL_CONTENT_ALLERGY, OUTPUT_XML_WITH_STATEMENT_REF_LINK_ALLERGY_OBSERVATION, false),
             Arguments.of(INPUT_JSON_WITH_ACTUAL_PROBLEM_MEDICATION_REQUEST, OUTPUT_XML_MEDICATION_REQUEST_ACTUAL_PROBLEM, false)
         );
-    }
-
-    @ParameterizedTest
-    @MethodSource("testObservationArguments")
-    public void When_MappingParsedConditionWithActualProblemContentAndIsObservation_Expect_LinkSetXml(String conditionJson,
-        String outputXml, boolean isNested) throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(conditionJson);
-        var expectedOutput = ResourceTestFileUtils.getFileContent(outputXml);
-        Condition condition = fhirParseService.parseResource(jsonInput, Condition.class);
-
-        String outputMessage = conditionLinkSetMapper.mapConditionToLinkSet(condition, isNested);
-        assertThat(outputMessage).isEqualTo(expectedOutput);
     }
 
     private static Stream<Arguments> testObservationArguments() {
@@ -260,48 +346,14 @@ public class ConditionLinkSetMapperTest {
         };
     }
 
-    @Test
-    public void When_MappingParsedConditionWithNoRelatedClinicalContent_Expect_LinkSetXml()
-        throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_NO_RELATED_CLINICAL_CONTENT);
-        var expectedOutput = ResourceTestFileUtils.getFileContent(OUTPUT_XML_WITH_NO_RELATED_CLINICAL_CONTENT);
-        Condition condition = fhirParseService.parseResource(jsonInput, Condition.class);
-
-        String outputMessage = conditionLinkSetMapper.mapConditionToLinkSet(condition, false);
-        assertThat(outputMessage).isEqualTo(expectedOutput);
+    private Condition getConditionResourceFromJson(String filename) {
+        final String filePath = TEST_FILES_DIRECTORY + filename;
+        return FileParsingUtility.parseResourceFromJsonFile(filePath, Condition.class);
     }
 
-    @Test
-    public void When_MappingParsedConditionWithNonExistentReferenceInRelatedClinicalContent_Expect_MapperException() throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_RELATED_CLINICAL_CONTENT_NON_EXISTENT_REFERENCE);
-        Condition parsedObservation = fhirParseService.parseResource(jsonInput, Condition.class);
-
-        when(messageContext.getInputBundleHolder()).thenReturn(inputBundle);
-
-        // TODO: workaround for NIAD-1409 should throw an exception but public demonstrator include invalid references
-        assumeThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(parsedObservation, false))
-            .isExactlyInstanceOf(EhrMapperException.class)
-            .hasMessage("Could not resolve Condition Related Medical Content reference");
-    }
-
-    @Test
-    public void When_MappingParsedConditionCodeIsMissing_Expect_MapperException() throws IOException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_MISSING_CONDITION_CODE);
-        Condition parsedObservation = fhirParseService.parseResource(jsonInput, Condition.class);
-
-        assertThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(parsedObservation, false))
-            .isExactlyInstanceOf(EhrMapperException.class)
-            .hasMessage("Condition code not present");
-    }
-
-    @Test
-    public void When_MappingConditionWith_SuppressedMedReqAsRelatedClinicalContent_Expect_NoEntry() throws IOException, SAXException {
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_SUPPRESSED_RELATED_MEDICATION_REQUEST);
-        var expectedOutput = ResourceTestFileUtils.getFileContent(OUTPUT_XML_SUPPRESSED_RELATED_MEDICATION_REQUEST);
-
-        Condition condition = fhirParseService.parseResource(jsonInput, Condition.class);
-        var mappedConditionOutput = conditionLinkSetMapper.mapConditionToLinkSet(condition, false);
-
-        XMLAssert.assertXMLEqual(expectedOutput, mappedConditionOutput);
+    private String getXmlStringFromFile(String filename) {
+        return ResourceTestFileUtils.getFileContent(
+            TEST_FILES_DIRECTORY + filename
+        );
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -166,7 +166,7 @@ public class EhrExtractMapperComponentTest {
                 messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
                 codeableConceptCdMapper, new ParticipantMapper()),
             new ConditionLinkSetMapper(
-                messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper),
+                messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
             new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -144,7 +144,8 @@ public class EncounterComponentsMapperTest {
         ConditionLinkSetMapper conditionLinkSetMapper = new ConditionLinkSetMapper(messageContext,
             randomIdGeneratorService,
             codeableConceptCdMapper,
-            participantMapper
+            participantMapper,
+            confidentialityService
         );
         DiaryPlanStatementMapper diaryPlanStatementMapper
             = new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -44,6 +44,7 @@ import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 
 import static org.mockito.ArgumentMatchers.anyList;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -79,8 +80,6 @@ class DiagnosticReportMapperTest {
     private static final String OUTPUT_XML_MULTIPLE_CODED_DIAGNOSIS = "diagnostic-report-with-multiple-coded-diagnosis.xml";
     private static final String OUTPUT_XML_EXTENSION_ID = "diagnostic-report-with-extension-id.xml";
     private static final String OUTPUT_XML_MULTIPLE_RESULTS = "diagnostic-report-with-multiple-results.xml";
-
-    private static final String NOPAT_CONFIDENTIALITY_CODE = ConfidentialityCodeUtility.getNopatHl7v3ConfidentialityCode();
 
     @Mock
     private CodeableConceptCdMapper codeableConceptCdMapper;
@@ -144,12 +143,12 @@ class DiagnosticReportMapperTest {
         final DiagnosticReport diagnosticReport = getDiagnosticReportResourceFromJson(testFile);
 
         when(confidentialityService.generateConfidentialityCode(diagnosticReport))
-            .thenReturn(Optional.of(NOPAT_CONFIDENTIALITY_CODE));
+            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
 
         final String result = mapper.mapDiagnosticReportToCompoundStatement(diagnosticReport);
 
         assertAll(
-            () -> assertThat(result).contains(NOPAT_CONFIDENTIALITY_CODE),
+            () -> assertThat(result).contains(NOPAT_HL7_CONFIDENTIALITY_CODE),
             () -> assertThat(ConfidentialityCodeUtility.getSecurityCodeFromResource(diagnosticReport)).isEqualTo("NOPAT")
         );
     }
@@ -165,7 +164,7 @@ class DiagnosticReportMapperTest {
         final String result = mapper.mapDiagnosticReportToCompoundStatement(diagnosticReport);
 
         assertAll(
-            () -> assertThat(result).doesNotContain(NOPAT_CONFIDENTIALITY_CODE),
+            () -> assertThat(result).doesNotContain(NOPAT_HL7_CONFIDENTIALITY_CODE),
             () -> assertThat(ConfidentialityCodeUtility.getSecurityCodeFromResource(diagnosticReport)).isEqualTo("NOSCRUB")
         );
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
@@ -45,13 +45,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
 
 @ExtendWith(MockitoExtension.class)
 class ObservationMapperTest {
     private static final String DIAGNOSTIC_REPORT_TEST_FILE_DIRECTORY = "/ehr/mapper/diagnosticreport/";
     private static final String OBSERVATION_TEST_FILE_DIRECTORY = "/ehr/mapper/diagnosticreport/observation/";
-    private static final String NOPAT_CONFIDENTIALITY_CODE
-        = ConfidentialityCodeUtility.getNopatHl7v3ConfidentialityCode();
 
     private static final String OBSERVATION_ASSOCIATED_WITH_SPECIMEN_1_JSON =
         "observation_associated_with_specimen_1.json";
@@ -207,11 +206,12 @@ class ObservationMapperTest {
     void When_MappingTestGroupHeader_With_NopatMetaSecurity_Expect_ConfidentialityCodeWithinCompoundStatement()
         throws XPathExpressionException, IOException, ParserConfigurationException, SAXException {
         final Observation observation = getObservationResourceFromJson(OBSERVATION_TEST_GROUP_HEADER_JSON);
-        final String xPath = "/component/CompoundStatement/confidentialityCode";
+        final String xPath = "/component/CompoundStatement/" + ConfidentialityCodeUtility
+            .getNopatConfidentialityCodeXpathSegment();
 
         ConfidentialityCodeUtility.appendNopatSecurityToMetaForResource(observation);
         when(confidentialityService.generateConfidentialityCode(observationArgumentCaptor.capture()))
-            .thenReturn(Optional.of(NOPAT_CONFIDENTIALITY_CODE));
+            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
 
         final String actualXml = observationMapper.mapObservationToCompoundStatement(observation);
 
@@ -239,7 +239,7 @@ class ObservationMapperTest {
             .filter(ConfidentialityCodeUtility::doesMetaContainNopat)
             .toList();
 
-        assertThat(actualXml).doesNotContainIgnoringCase(NOPAT_CONFIDENTIALITY_CODE);
+        assertThat(actualXml).doesNotContainIgnoringCase(NOPAT_HL7_CONFIDENTIALITY_CODE);
         assertThat(metaWithNopat).hasSize(0);
     }
 
@@ -247,11 +247,12 @@ class ObservationMapperTest {
     void When_MappingTestResult_With_NopatMetaSecurity_Expect_ConfidentialityCodeWithinObservationStatement()
         throws XPathExpressionException, IOException, ParserConfigurationException, SAXException {
         final Observation observation = getObservationResourceFromJson(OBSERVATION_TEST_RESULT_JSON);
-        final String xPath = "/component/ObservationStatement/confidentialityCode";
+        final String xPath = "/component/ObservationStatement/" + ConfidentialityCodeUtility
+            .getNopatConfidentialityCodeXpathSegment();
 
         ConfidentialityCodeUtility.appendNopatSecurityToMetaForResource(observation);
         when(confidentialityService.generateConfidentialityCode(observation))
-            .thenReturn(Optional.of(NOPAT_CONFIDENTIALITY_CODE));
+            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
 
         final String actualXml = observationMapper.mapObservationToCompoundStatement(observation);
 
@@ -268,18 +269,19 @@ class ObservationMapperTest {
 
         final String actualXml = observationMapper.mapObservationToCompoundStatement(observation);
 
-        assertThat(actualXml).doesNotContainIgnoringCase(NOPAT_CONFIDENTIALITY_CODE);
+        assertThat(actualXml).doesNotContainIgnoringCase(NOPAT_HL7_CONFIDENTIALITY_CODE);
     }
 
     @Test
     void When_MappingFilingComment_With_NopatMetaSecurity_Expect_ConfidentialityCodeWithinNarrativeStatement()
         throws XPathExpressionException, IOException, ParserConfigurationException, SAXException {
         final Observation observation = getObservationResourceFromJson(OBSERVATION_FILING_COMMENT_JSON);
-        final String xPath = "/component/NarrativeStatement/confidentialityCode";
+        final String xPath = "/component/NarrativeStatement/" + ConfidentialityCodeUtility
+            .getNopatConfidentialityCodeXpathSegment();
 
         ConfidentialityCodeUtility.appendNopatSecurityToMetaForResource(observation);
         when(confidentialityService.generateConfidentialityCode(observation))
-            .thenReturn(Optional.of(NOPAT_CONFIDENTIALITY_CODE));
+            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
 
         final String actualXml = observationMapper.mapObservationToCompoundStatement(observation);
 
@@ -296,7 +298,7 @@ class ObservationMapperTest {
 
         final String actualXml = observationMapper.mapObservationToCompoundStatement(observation);
 
-        assertThat(actualXml).doesNotContainIgnoringCase(NOPAT_CONFIDENTIALITY_CODE);
+        assertThat(actualXml).doesNotContainIgnoringCase(NOPAT_HL7_CONFIDENTIALITY_CODE);
     }
 
     private String getXmlStringFromFile(String filename) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/SpecimenMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/SpecimenMapperTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
 
 import java.util.Collections;
 import java.util.List;
@@ -51,7 +52,6 @@ class SpecimenMapperTest {
     private static final String INPUT_OBSERVATION_RELATED_TO_SPECIMEN = "input-observation-related-to-specimen.json";
     private static final String INPUT_OBSERVATION_NOT_RELATED_TO_SPECIMEN = "input-observation-not-related-to-specimen.json";
     private static final String TEST_ID = "5E496953-065B-41F2-9577-BE8F2FBD0757";
-    private static final String NOPAT_CONFIDENTIALITY_CODE = ConfidentialityCodeUtility.getNopatHl7v3ConfidentialityCode();
     private static final String ID_FROM_ID_MAPPER = "some-id";
     private static final DiagnosticReport DIAGNOSTIC_REPORT = new DiagnosticReport().setIssuedElement(
         new InstantType(DIAGNOSTIC_REPORT_DATE)
@@ -166,7 +166,7 @@ class SpecimenMapperTest {
         ConfidentialityCodeUtility.appendNopatSecurityToMetaForResource(specimen);
 
         when(confidentialityService.generateConfidentialityCode(specimen))
-            .thenReturn(Optional.of(NOPAT_CONFIDENTIALITY_CODE));
+            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
         when(idMapper.getOrNew(any(ResourceType.class), any(IdType.class)))
             .thenReturn(ID_FROM_ID_MAPPER);
 
@@ -174,7 +174,7 @@ class SpecimenMapperTest {
             Collections.emptyList(), DIAGNOSTIC_REPORT);
 
         assertAll(
-            () -> assertThat(result).contains(NOPAT_CONFIDENTIALITY_CODE),
+            () -> assertThat(result).contains(NOPAT_HL7_CONFIDENTIALITY_CODE),
             () -> assertThat(ConfidentialityCodeUtility.getSecurityCodeFromResource(specimen)).isEqualTo("NOPAT")
         );
     }
@@ -194,7 +194,7 @@ class SpecimenMapperTest {
             Collections.emptyList(), DIAGNOSTIC_REPORT);
 
         assertAll(
-            () -> assertThat(result).doesNotContain(NOPAT_CONFIDENTIALITY_CODE),
+            () -> assertThat(result).doesNotContain(NOPAT_HL7_CONFIDENTIALITY_CODE),
             () -> assertThat(ConfidentialityCodeUtility.getSecurityCodeFromResource(specimen)).isEqualTo("NOSCRUB")
         );
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -186,7 +186,7 @@ public class EhrExtractUATTest {
                 messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
                 codeableConceptCdMapper, new ParticipantMapper()),
             new ConditionLinkSetMapper(
-                messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper),
+                messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
             new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/ConfidentialityCodeUtility.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/ConfidentialityCodeUtility.java
@@ -8,7 +8,9 @@ import java.util.Collections;
 
 public final class ConfidentialityCodeUtility {
     private ConfidentialityCodeUtility() { }
-    private static final String NOPAT_CONFIDENTIALITY_CODE = """
+    public static final String NOPAT = "NOPAT";
+    public static final String NOSCRUB = "NOSCRUB";
+    public static final String NOPAT_HL7_CONFIDENTIALITY_CODE = """
         <confidentialityCode
             code="NOPAT"
             codeSystem="2.16.840.1.113883.4.642.3.47"
@@ -40,10 +42,6 @@ public final class ConfidentialityCodeUtility {
         );
     }
 
-    public static String getNopatHl7v3ConfidentialityCode() {
-        return NOPAT_CONFIDENTIALITY_CODE;
-    }
-
     public static boolean doesMetaContainNopat(Meta meta) {
         if (!meta.getSecurity().isEmpty()) {
             final Coding coding = meta.getSecurity().getFirst();
@@ -51,6 +49,16 @@ public final class ConfidentialityCodeUtility {
         }
 
         return false;
+    }
+
+    public static String getNopatConfidentialityCodeXpathSegment() {
+        return """
+            confidentialityCode[
+                @code='NOPAT' and
+                @codeSystem='2.16.840.1.113883.4.642.3.47' and
+                @displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+            ]
+            """;
     }
 
     private static Coding getNopatCoding() {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/XmlParsingUtility.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/XmlParsingUtility.java
@@ -39,6 +39,25 @@ public final class XmlParsingUtility {
             .evaluate(document, XPathConstants.NODESET);
     }
 
+    /**
+     * Wraps a given XML string within a root element.
+     * <p>
+     * This method is useful when working with XML fragments or segments that do not have a single root element.
+     * Such fragments are not well-formed XML documents, making them incompatible with certain XML parsers
+     * or operations, such as XPath queries, which require a single root element to function correctly.
+     * </p>
+     * <p>
+     * By wrapping the provided XML string within a Root element, this method ensures that the resulting
+     * XML is well-formed and can be safely processed with XML tools.
+     * </p>
+     *
+     * @param xmlString the XML string that may lack a root element
+     * @return a well-formed XML string with the provided content wrapped inside a Root element
+     */
+    public static String wrapXmlInRootElement(String xmlString) {
+        return "<Root>%s</Root>".formatted(xmlString);
+    }
+
     public static boolean xpathMatchFound(String xmlString, String xPathExpression) throws
         XPathExpressionException, IOException, ParserConfigurationException, SAXException {
         final NodeList nodeList = getNodeListFromXpath(xmlString, xPathExpression);


### PR DESCRIPTION
## What

Given a scenario where we receive a `Condition` with the `meta.security` value populated with `NOPAT`, then this PR contains the functionality to append the HL7v3 `confidentialityCode` to the `LinkSet` resource being mapped.

## Why

Please see the [ticket](https://nhse-dsic.atlassian.net/browse/NIAD-3147) for more information.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
