### PR TITLE
Replace Apache HTTP Header imports with Spring HttpHeaders class

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/builder/GpcRequestBuilder.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/builder/GpcRequestBuilder.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.Parameters.ParametersParameterComponent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -36,8 +37,6 @@ import uk.nhs.adaptors.gp2gp.gpc.configuration.GpcConfiguration;
 import java.util.Collections;
 
 import static java.lang.String.valueOf;
-import static org.apache.http.protocol.HTTP.CONTENT_LEN;
-import static org.apache.http.protocol.HTTP.CONTENT_TYPE;
 
 @Component
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -146,13 +145,13 @@ public class GpcRequestBuilder {
         return uri.accept(MediaType.valueOf(FHIR_CONTENT_TYPE))
             .header(SSP_INTERACTION_ID, interactionId)
             .header(SSP_TRACE_ID, taskDefinition.getConversationId())
-            .header(CONTENT_TYPE, FHIR_CONTENT_TYPE);
+            .header(HttpHeaders.CONTENT_TYPE, FHIR_CONTENT_TYPE);
     }
 
     private RequestHeadersSpec<?> buildRequestWithHeadersAndBody(RequestBodySpec uri, String requestBody,
         BodyInserter<Object, ReactiveHttpOutputMessage> bodyInserter, TaskDefinition taskDefinition, String interactionId) {
         return buildRequestWithHeaders(uri, taskDefinition, interactionId)
             .body(bodyInserter)
-            .header(CONTENT_LEN, valueOf(requestBody.length()));
+            .header(HttpHeaders.CONTENT_LENGTH, valueOf(requestBody.length()));
     }
 }


### PR DESCRIPTION
## Why

We don't explicitly depend on the Apache library, so switch to one we do.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
