### PR TITLE
NIAD-3149: Add confidentialityCode to Immunizations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ will contain a `NOPAT` `confidentialityCode` element.
   for that resource will contain a `NOPAT` `confidentialityCode` element.
 * When mapping a `Condition` which contains a `NOPAT` `meta.security` tag the resultant XML for that resource
   will contain a `NOPAT` `confidentialityCode` element.
+* * When mapping `Immunizations` which contain a `NOPAT` `meta.security` tag, the resultant XML for that resource
+    will contain a `NOPAT` `confidentialityCode` element.
 
 ## [2.0.6] - 2024-07-29
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/ImmunizationObservationStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/ImmunizationObservationStatementTemplateParameters.java
@@ -11,6 +11,7 @@ public class ImmunizationObservationStatementTemplateParameters {
     private boolean isNested;
     private String observationStatementId;
     private String availabilityTime;
+    private String confidentialityCode;
     private String effectiveTime;
     private String pertinentInformation;
     private String code;

--- a/service/src/main/resources/templates/ehr_immunization_observation_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_immunization_observation_statement_template.mustache
@@ -6,7 +6,10 @@
         <effectiveTime>
             {{#effectiveTime}}<center value="{{effectiveTime}}"/>{{/effectiveTime}}{{^effectiveTime}}<center nullFlavor="UNK"/>{{/effectiveTime}}
         </effectiveTime>
-        <availabilityTime {{#availabilityTime}}value="{{availabilityTime}}"{{/availabilityTime}}{{^availabilityTime}}nullFlavor="UNK"{{/availabilityTime}} />
+        <availabilityTime {{#availabilityTime}}value="{{availabilityTime}}" {{/availabilityTime}}{{^availabilityTime}}nullFlavor="UNK"{{/availabilityTime}} />
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#pertinentInformation}}
         <pertinentInformation typeCode="PERT">
             <sequenceNumber value="+1"/>

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
@@ -1,61 +1,51 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import org.hl7.fhir.dstu3.model.CodeableConcept;
-import org.hl7.fhir.dstu3.model.ResourceType;
-import org.hl7.fhir.dstu3.model.Condition;
-import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.IdType;
-
-import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
-import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
-import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
-import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
-import uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility;
-import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
-import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
-import uk.nhs.adaptors.gp2gp.utils.FileParsingUtility;
-import uk.nhs.adaptors.gp2gp.utils.XmlParsingUtility;
-
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.Arguments;
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.ResourceType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.xml.sax.SAXException;
-
-import java.io.IOException;
-
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
+import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
+import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
+import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
+import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
+import uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility;
+import uk.nhs.adaptors.gp2gp.utils.FileParsingUtility;
+import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 import wiremock.org.custommonkey.xmlunit.XMLAssert;
 
-import java.util.stream.Stream;
+import java.io.IOException;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertAll;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
-
-import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
-import static uk.nhs.adaptors.gp2gp.utils.XmlParsingUtility.wrapXmlInRootElement;
-import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOSCRUB;
 import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOSCRUB;
 import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
+import static uk.nhs.adaptors.gp2gp.utils.XmlAssertion.assertThatXml;
+import static uk.nhs.adaptors.gp2gp.utils.XmlParsingUtility.wrapXmlInRootElement;
 
 @ExtendWith(MockitoExtension.class)
 class ConditionLinkSetMapperTest {
@@ -282,8 +272,8 @@ class ConditionLinkSetMapperTest {
             .getSecurityCodeFromResource(conditionArgumentCaptor.getValue());
 
         assertAll(
-            () -> assertTrue(XmlParsingUtility.xpathMatchFound(actualXml, observationStatementXpath)),
-            () -> assertTrue(XmlParsingUtility.xpathMatchFound(actualXml, linkSetXpath)),
+            () -> assertThatXml(actualXml).containsXPath(observationStatementXpath),
+            () -> assertThatXml(actualXml).containsXPath(linkSetXpath),
             () -> assertThat(conditionSecurityCode).isEqualTo(NOPAT)
         );
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -169,7 +169,12 @@ public class EhrExtractMapperComponentTest {
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
-            new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new ImmunizationObservationStatementMapper(
+                messageContext,
+                codeableConceptCdMapper,
+                participantMapper,
+                confidentialityService
+            ),
             new MedicationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, randomIdGeneratorService),
             new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
             new ObservationStatementMapper(

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -1,17 +1,5 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.when;
-
-import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
-
-import java.util.List;
-import java.util.stream.Stream;
-
 import org.hl7.fhir.dstu3.model.AllergyIntolerance;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
@@ -29,7 +17,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
@@ -43,6 +30,17 @@ import uk.nhs.adaptors.gp2gp.ehr.utils.BloodPressureValidator;
 import uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils;
 import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EncounterComponentsMapperTest {
@@ -165,7 +163,12 @@ public class EncounterComponentsMapperTest {
             participantMapper
         );
         ImmunizationObservationStatementMapper immunizationObservationStatementMapper =
-            new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper);
+            new ImmunizationObservationStatementMapper(
+                messageContext,
+                codeableConceptCdMapper,
+                participantMapper,
+                confidentialityService
+            );
         RequestStatementMapper requestStatementMapper
             = new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper);
         DiagnosticReportMapper diagnosticReportMapper = new DiagnosticReportMapper(

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
@@ -241,7 +241,7 @@ public class ImmunizationObservationStatementMapperTest {
         );
     }
 
-    @Test
+    @Test()
     void When_MappingImmunizationWithInvalidPractitionerReferenceType_Expect_Error() {
         var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_PRACTITIONER_INVALID_REFERENCE_RESOURCE_TYPE);
         Immunization parsedImmunization = fhirParseService.parseResource(jsonInput, Immunization.class);
@@ -252,7 +252,7 @@ public class ImmunizationObservationStatementMapperTest {
     }
 
     @Test
-    void When_ConfidentialityServiceReturnsConfidentialityCode_Expect_MessageContainsConfidentialityCode() {
+    void When_MappingImmunizationWithoutNopatMetaSecurity_Expect_MessageContainsConfidentialityCode() {
         final var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_PERTINENT_INFORMATION);
         final var parsedImmunization = fhirParseService.parseResource(jsonInput, Immunization.class);
         when(confidentialityService.generateConfidentialityCode(parsedImmunization))
@@ -268,7 +268,7 @@ public class ImmunizationObservationStatementMapperTest {
     }
 
     @Test
-    void When_ConfidentialityServiceReturnsEmptyOptional_Expect_MessageDoesNotContainConfidentialityCode() {
+    void When_MappingImmunizationWithoutNoNopatMetaSecurity_Expect_MessageDoesNotContainConfidentialityCode() {
         final var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_PERTINENT_INFORMATION);
         final var parsedImmunization = fhirParseService.parseResource(jsonInput, Immunization.class);
         when(confidentialityService.generateConfidentialityCode(parsedImmunization))

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -149,12 +150,6 @@ public class ImmunizationObservationStatementMapperTest {
         + "expected-output-observation-statement-all-multiple-practitioners.xml";
     private static final String OUTPUT_XML_WITH_MULTIPLE_PRACTITIONERS_NO_AP_ROLE = IMMUNIZATION_FILE_LOCATIONS
         + "expected-output-observation-statement-all-multiple-practitioners-no-AP-role.xml";
-    private static final String CONFIDENTIALITY_CODE = """
-        <confidentialityCode
-            code="NOPAT"
-            codeSystem="2.16.840.1.113883.4.642.3.47"
-            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
-        />""";
 
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
@@ -170,7 +165,7 @@ public class ImmunizationObservationStatementMapperTest {
     private FhirParseService fhirParseService;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
         when(randomIdGeneratorService.createNewOrUseExistingUUID(anyString())).thenReturn(TEST_ID);
         when(codeableConceptCdMapper.mapCodeableConceptToCd(any(CodeableConcept.class)))
@@ -189,13 +184,13 @@ public class ImmunizationObservationStatementMapperTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         messageContext.resetMessageContext();
     }
 
     @ParameterizedTest
     @MethodSource("resourceFileParams")
-    public void When_MappingImmunizationJson_Expect_ObservationStatementXmlOutput(String inputJson, String outputXml,
+    void When_MappingImmunizationJson_Expect_ObservationStatementXmlOutput(String inputJson, String outputXml,
                                                                                   boolean isNested) {
         var expectedOutput = ResourceTestFileUtils.getFileContent(outputXml);
         var jsonInput = ResourceTestFileUtils.getFileContent(inputJson);
@@ -247,7 +242,7 @@ public class ImmunizationObservationStatementMapperTest {
     }
 
     @Test
-    public void When_MappingImmunizationWithInvalidPractitionerReferenceType_Expect_Error() {
+    void When_MappingImmunizationWithInvalidPractitionerReferenceType_Expect_Error() {
         var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_PRACTITIONER_INVALID_REFERENCE_RESOURCE_TYPE);
         Immunization parsedImmunization = fhirParseService.parseResource(jsonInput, Immunization.class);
 
@@ -257,11 +252,11 @@ public class ImmunizationObservationStatementMapperTest {
     }
 
     @Test
-    public void When_ConfidentialityServiceReturnsConfidentialityCode_Expect_MessageContainsConfidentialityCode() {
+    void When_ConfidentialityServiceReturnsConfidentialityCode_Expect_MessageContainsConfidentialityCode() {
         final var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_PERTINENT_INFORMATION);
         final var parsedImmunization = fhirParseService.parseResource(jsonInput, Immunization.class);
         when(confidentialityService.generateConfidentialityCode(parsedImmunization))
-            .thenReturn(Optional.of(CONFIDENTIALITY_CODE));
+            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
 
         final var actualMessage = observationStatementMapper.mapImmunizationToObservationStatement(
             parsedImmunization,
@@ -269,11 +264,11 @@ public class ImmunizationObservationStatementMapperTest {
         );
 
         assertThat(actualMessage)
-            .contains(CONFIDENTIALITY_CODE);
+            .contains(NOPAT_HL7_CONFIDENTIALITY_CODE);
     }
 
     @Test
-    public void When_ConfidentialityServiceReturnsEmptyOptional_Expect_MessageDoesNotContainConfidentialityCode() {
+    void When_ConfidentialityServiceReturnsEmptyOptional_Expect_MessageDoesNotContainConfidentialityCode() {
         final var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_PERTINENT_INFORMATION);
         final var parsedImmunization = fhirParseService.parseResource(jsonInput, Immunization.class);
         when(confidentialityService.generateConfidentialityCode(parsedImmunization))
@@ -285,6 +280,6 @@ public class ImmunizationObservationStatementMapperTest {
         );
 
         assertThat(actualMessage)
-            .doesNotContain(CONFIDENTIALITY_CODE);
+            .doesNotContain(NOPAT_HL7_CONFIDENTIALITY_CODE);
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ImmunizationObservationStatementMapperTest.java
@@ -19,6 +19,7 @@ import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
+import uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 
 import java.io.IOException;
@@ -31,13 +32,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.nhs.adaptors.gp2gp.utils.ConfidentialityCodeUtility.NOPAT_HL7_CONFIDENTIALITY_CODE;
+import static uk.nhs.adaptors.gp2gp.utils.XmlAssertion.assertThatXml;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ImmunizationObservationStatementMapperTest {
     private static final String TEST_ID = "test-id";
-
     private static final String IMMUNIZATION_FILE_LOCATIONS = "/ehr/mapper/immunization/";
+    private static final String OBSERVATION_STATEMENT_CONFIDENTIALITY_CODE_XPATH =
+        "/component/ObservationStatement/" + ConfidentialityCodeUtility.getNopatConfidentialityCodeXpathSegment();
+
     private static final String INPUT_JSON_WITH_PERTINENT_INFORMATION = IMMUNIZATION_FILE_LOCATIONS
         + "immunization-all-pertinent-information.json";
     private static final String INPUT_JSON_WITHOUT_REQUIRED_PERTINENT_INFORMATION = IMMUNIZATION_FILE_LOCATIONS
@@ -263,8 +267,8 @@ public class ImmunizationObservationStatementMapperTest {
             false
         );
 
-        assertThat(actualMessage)
-            .contains(NOPAT_HL7_CONFIDENTIALITY_CODE);
+        assertThatXml(actualMessage)
+            .containsXPath(OBSERVATION_STATEMENT_CONFIDENTIALITY_CODE_XPATH);
     }
 
     @Test
@@ -279,7 +283,7 @@ public class ImmunizationObservationStatementMapperTest {
             false
         );
 
-        assertThat(actualMessage)
-            .doesNotContain(NOPAT_HL7_CONFIDENTIALITY_CODE);
+        assertThatXml(actualMessage)
+            .doesNotContainXPath(OBSERVATION_STATEMENT_CONFIDENTIALITY_CODE_XPATH);
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -189,7 +189,12 @@ public class EhrExtractUATTest {
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
-            new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new ImmunizationObservationStatementMapper(
+                messageContext,
+                codeableConceptCdMapper,
+                participantMapper,
+                confidentialityService
+            ),
             new MedicationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, randomIdGeneratorService),
             new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
             new ObservationStatementMapper(

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/XmlAssertion.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/XmlAssertion.java
@@ -1,0 +1,63 @@
+package uk.nhs.adaptors.gp2gp.utils;
+
+import lombok.SneakyThrows;
+import org.assertj.core.api.AbstractAssert;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+public class XmlAssertion extends AbstractAssert<XmlAssertion, String> {
+
+    protected XmlAssertion(String xml) {
+        super(xml, XmlAssertion.class);
+    }
+
+    /**
+     * Create an assertion for a {@link String} XML value.
+     * @param actual the actual XML value.
+     * @return the created assertion object.
+     */
+    @Contract("_ -> new")
+    public static @NotNull XmlAssertion assertThatXml(String actual) {
+        return new XmlAssertion(actual);
+    }
+
+    /**
+     * Verifies that the actual {@link String} XML contains the given XPath value.
+     * @param expectedXPath the {@link String} XPath value expected to be found within the provided XML.
+     */
+    @SneakyThrows
+    public void containsXPath(String expectedXPath) {
+        isNotNull();
+        if (!XmlParsingUtility.xpathMatchFound(actual, expectedXPath)) {
+            failWithMessage(
+                """
+                    Expected to find expectedXPath in XML, but it was not present.
+
+                    <XPath>: %s
+                    <XML>: %s""",
+                expectedXPath,
+                actual
+            );
+        }
+    }
+
+    /**
+     * Verifies that the actual {@link String} XML does not contain the given XPath value.
+     * @param xPath the {@link String} XPath value expected to not be found within the provided XML.
+     */
+    @SneakyThrows
+    public void doesNotContainXPath(String xPath) {
+        isNotNull();
+        if (XmlParsingUtility.xpathMatchFound(actual, xPath)) {
+            failWithMessage(
+                """
+                Expected not to find xPath in XML, but it was present.
+
+                <XPath>: %s
+                <XML>: %s""",
+                xPath,
+                actual
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

* Add functionality for `confidentialityCode` to be include in mapped immunization, when the input contains `NOPAT` meta security tag.
* Add Unit Tests to `ImmunizationObservationStatementMapperTest` to test mapping of `confidentialityCode` when `NOPAT` Meta securityTag is present or not present
* Update `ImmunizationObservationStatementMapper` to inject ConfidentialityService and to add parameter for confidentiality service to `ImmunizationObservationStatementTemplateParameters`. 
* Update mustache template to include mapping for `confidentialityCode`.
* Update injection of ConfidentialityService in related test files. 
* Update CHANGELOG.md


## Why

A requirement for the Redactions work is to add NOPAT confidentialityCode handling to `Immunizations`:

_GP2GP Adaptor populates the ObservationStatement / confidentialityCode field when the `Immunization.meta.security` field is populated with `NOPAT` and the message type is `RCMR_IN030000UK07`._

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
