### PR TITLE
NIAD-2840: Identifies no acknowledgment after 8 Days

### DIFF
--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrAcknowledgementTest.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrAcknowledgementTest.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.nhs.adaptors.gp2gp.common.ResourceReader.asString;
 
 import java.util.Optional;
@@ -29,6 +30,7 @@ import uk.nhs.adaptors.gp2gp.testcontainers.MongoDBExtension;
 @SpringBootTest
 @DirtiesContext
 public class EhrAcknowledgementTest {
+
     private static final String ROOT_ID = "75049C80-5271-11EA-9384-E83935108FD5";
     private static final String MESSAGE_REF = "BA229526-ADC6-4F1D-970E-CD9E78A6830E";
     private static final String BUSINESS_ERROR_CODE = "99";
@@ -62,7 +64,7 @@ public class EhrAcknowledgementTest {
                 () -> assertThat(ack.getReceived()).isEqualTo(ack.getConversationClosed()),
                 () -> assertThat(ack.getMessageRef()).isEqualTo(MESSAGE_REF),
                 () -> assertThat(ack.getRootId()).isEqualTo(ROOT_ID),
-                () -> assertThat(ack.getErrors()).isNull()
+                () -> assertNull(ack.getErrors())
             ));
     }
 

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceIT.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceIT.java
@@ -53,6 +53,7 @@ public class EhrExtractStatusServiceIT {
     private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
     private static final int DEFAULT_CONTENT_LENGTH = 244;
     private static final String CONTENT_TYPE_MSWORD = "application/msword";
+    public static final String JSON_SUFFIX = ".json";
 
     @Autowired
     private EhrExtractStatusService ehrExtractStatusService;
@@ -124,7 +125,7 @@ public class EhrExtractStatusServiceIT {
     public void When_FetchDocumentObjectNameAndSize_With_InvalidConversation_Expect_EmptyMap() {
         final var fakeConversationId = generateRandomUppercaseUUID();
 
-        assertThat(ehrExtractStatusService.fetchDocumentObjectNameAndSize(fakeConversationId)).isEqualTo(Collections.EMPTY_MAP);
+        assertThat(ehrExtractStatusService.fetchDocumentObjectNameAndSize(fakeConversationId)).isEqualTo(Collections.emptyMap());
     }
 
     @Test
@@ -455,7 +456,7 @@ public class EhrExtractStatusServiceIT {
                         .build())
                 .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
                         .accessedAt(FIVE_DAYS_AGO)
-                        .objectName(generateRandomUppercaseUUID() + ".json")
+                        .objectName(generateRandomUppercaseUUID() + JSON_SUFFIX)
                         .taskId(generateRandomUppercaseUUID())
                         .build())
                 .messageTimestamp(FIVE_DAYS_AGO)

--- a/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceIT.java
+++ b/service/src/intTest/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceIT.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.gp2gp.ehr;
 
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -164,7 +165,7 @@ public class EhrExtractStatusServiceIT {
 
         List<EhrExtractStatus> results = ehrExtractStatusService.findInProgressTransfers();
 
-        assertThat(results.isEmpty()).isTrue();
+        assertTrue(results.isEmpty());
     }
 
     @Test

--- a/service/src/intTest/resources/application.yml
+++ b/service/src/intTest/resources/application.yml
@@ -68,3 +68,6 @@ gp2gp:
       max-backoff-attempts: 3
       min-back-off: 2
       timeout: 3
+
+timeout:
+  cronTime: ${TIMEOUT_CRON_TIME:0 0 */12 * * *}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/configuration/Gp2gpConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/configuration/Gp2gpConfiguration.java
@@ -5,10 +5,12 @@ import org.springframework.context.annotation.Configuration;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Getter
 @Setter
 @Configuration
+@EnableScheduling
 @ConfigurationProperties(prefix = "gp2gp")
 public class Gp2gpConfiguration {
     private int largeAttachmentThreshold;

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -677,6 +677,11 @@ public class EhrExtractStatusService {
     private boolean hasAcknowledgementExceededEightDays(String conversationId, Instant ackReceivedTimestamp) {
         var ehrExtractStatus = fetchEhrExtractStatus(conversationId, "ACK");
 
+
+        if (ehrExtractStatus.getEhrExtractCorePending() == null) {
+            return false;
+        }
+
         Duration duration = Duration.between(ehrExtractStatus.getEhrExtractCorePending().getSentAt(), ackReceivedTimestamp);
         long daysSinceLastUpdate = duration.toDays();
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -384,8 +384,7 @@ public class EhrExtractStatusService {
         }
 
         var ehrReceivedAckErrorDetailsThatContainsSearchedErrCodeAndMsg = errors.stream()
-            .filter(err -> REASON_ERROR_CODE.equals(err.getCode())
-                           && REASON_ERROR_MESSAGE.equals(err.getDisplay()))
+            .filter(err -> REASON_ERROR_CODE.equals(err.getCode()) && REASON_ERROR_MESSAGE.equals(err.getDisplay()))
             .findAny();
 
         return ehrReceivedAckErrorDetailsThatContainsSearchedErrCodeAndMsg.isPresent();
@@ -716,8 +715,8 @@ public class EhrExtractStatusService {
     }
 
     private EhrExtractStatus fetchEhrExtractStatus(String conversationId, String messageType) {
-        return ehrExtractStatusRepository.findByConversationId(conversationId)
-            .orElseThrow(() -> new UnrecognisedInteractionIdException(messageType, conversationId));
+        return Optional.ofNullable(ehrExtractStatusRepository.findByConversationId(conversationId))
+            .orElseThrow(() -> new UnrecognisedInteractionIdException(messageType, conversationId)).get();
     }
 
     protected Logger logger() {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -321,18 +321,18 @@ public class EhrExtractStatusService {
     public void updateEhrExtractStatusAck(String conversationId, EhrReceivedAcknowledgement ack) {
 
         if (ack.getErrors() == null && !isEhrStatusWaitingForFinalAck(conversationId)) {
-            logger().warn("Received unexpected acknowledgement of EHR Extract with conversation id=" + conversationId);
+            logger().warn("Received unexpected acknowledgement of EHR Extract with conversation_id: {}", conversationId);
             return;
         }
 
         if (hasAcknowledgementExceededEightDays(conversationId, ack.getReceived())
             && hasEhrStatusReceivedAckWithErrors(conversationId)) {
-            logger().warn("Received an ACK message with a conversation_id: " + conversationId + ", but it will be ignored.");
+            logger().warn("Received an ACK message with a conversation_id: {}, but it will be ignored.", conversationId);
             return;
         }
 
         if (hasFinalAckBeenReceived(conversationId)) {
-            logger().warn("Received an ACK message with a conversation_id=" + conversationId + " that is a duplicate");
+            logger().warn("Received an ACK message with a conversation_id: {} that is a duplicate", conversationId);
             return;
         }
 
@@ -363,7 +363,7 @@ public class EhrExtractStatusService {
                 + "' that is not recognised");
         }
 
-        logger().info("Database successfully updated with EHRAcknowledgement, conversation_id: " + conversationId);
+        logger().info("Database successfully updated with EHRAcknowledgement, conversation_id: {}", conversationId);
     }
 
     private boolean hasEhrStatusReceivedAckWithErrors(String conversationId) {
@@ -563,13 +563,13 @@ public class EhrExtractStatusService {
         var failedNme = new Criteria();
         failedNme.andOperator(
             Criteria.where("ackPending.typeCode").is("AE"),
-            Criteria.where("error").exists(true));
+            Criteria.where(ERROR).exists(true));
 
         var complete = new Criteria();
         complete.andOperator(
             Criteria.where("ackPending.typeCode").is("AA"),
             Criteria.where("ackToRequester.typeCode").is("AA"),
-            Criteria.where("error").exists(false),
+            Criteria.where(ERROR).exists(false),
             Criteria.where("ehrReceivedAcknowledgement.conversationClosed").exists(true),
             Criteria.where("ehrReceivedAcknowledgement.errors").exists(false)
         );
@@ -709,8 +709,7 @@ public class EhrExtractStatusService {
         }
 
         if (ehrExtractStatus.getEhrContinue() != null) {
-            logger().warn("Received a Continue message with a conversation_id '" + conversationId
-                + "' that is duplicate");
+            logger().warn("Received a Continue message with a conversation_id: {} that is duplicate", conversationId);
             return true;
         }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +22,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-
 import com.mongodb.client.result.UpdateResult;
 
 import lombok.RequiredArgsConstructor;
@@ -42,6 +40,7 @@ import uk.nhs.adaptors.gp2gp.mhs.exception.UnrecognisedInteractionIdException;
 @Slf4j
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class EhrExtractStatusService {
+
     private static final String DOT = ".";
     private static final String ARRAY_REFERENCE = ".$.";
     private static final String CONVERSATION_ID = "conversationId";

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -365,13 +365,9 @@ public class EhrExtractStatusService {
         logger().info("Database successfully updated with EHRAcknowledgement, conversation_id: {}", conversationId);
     }
 
-    private boolean hasEhrStatusReceivedAckWithErrors(String conversationId) {
+    boolean hasEhrStatusReceivedAckWithErrors(String conversationId) {
 
         var ehrExtractStatus = fetchEhrExtractStatus(conversationId, "NACK");
-
-        if (ehrExtractStatus == null) {
-            return false;
-        }
 
         var ehrReceivedAcknowledgement = ehrExtractStatus.getEhrReceivedAcknowledgement();
         if (ehrReceivedAcknowledgement == null) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -480,9 +480,9 @@ public class EhrExtractStatusService {
         });
     }
 
-    public EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAckError(String conversationId,
-                                                                          String errorCode,
-                                                                          String errorMessage) {
+    protected EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAckError(String conversationId,
+                                                                            String errorCode,
+                                                                            String errorMessage) {
 
         Update update = createUpdateWithUpdatedAt();
         update.addToSet(RECEIVED_ACK_ERRORS, ErrorDetails.builder().code(errorCode).display(errorMessage).build());

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -711,8 +711,8 @@ public class EhrExtractStatusService {
     }
 
     private EhrExtractStatus fetchEhrExtractStatus(String conversationId, String messageType) {
-        return Optional.ofNullable(ehrExtractStatusRepository.findByConversationId(conversationId))
-            .orElseThrow(() -> new UnrecognisedInteractionIdException(messageType, conversationId)).get();
+        return ehrExtractStatusRepository.findByConversationId(conversationId)
+            .orElseThrow(() -> new UnrecognisedInteractionIdException(messageType, conversationId));
     }
 
     protected Logger logger() {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -137,7 +137,7 @@ public class EhrExtractStatusService {
             .filter(this::hasLastUpdateExceededEightDays)
             .toList();
 
-        if(!ehrExtractStatusWithExceededUpdateLimit.isEmpty()) {
+        if (!ehrExtractStatusWithExceededUpdateLimit.isEmpty()) {
             updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(ehrExtractStatusWithExceededUpdateLimit,
                                                                           REASON_ERROR_CODE,
                                                                           REASON_ERROR_MESSAGE);
@@ -470,16 +470,16 @@ public class EhrExtractStatusService {
                                                                               String errorCode,
                                                                               String errorMessage) {
 
-            ehrExtractStatusList.stream().forEach(ehrExtractStatus -> {
-                try {
-                    updateEhrExtractStatusWithEhrReceivedAcknowledgementError(ehrExtractStatus.getConversationId(),
-                                                                              errorCode,
-                                                                              errorMessage);
-                } catch (Exception e) {
-                    logger().error("An error occurred when closing a failed process for conversation_id: {}",
-                                 ehrExtractStatus.getConversationId(), e);
-                }
-            });
+        ehrExtractStatusList.stream().forEach(ehrExtractStatus -> {
+            try {
+                updateEhrExtractStatusWithEhrReceivedAcknowledgementError(ehrExtractStatus.getConversationId(),
+                                                                          errorCode,
+                                                                          errorMessage);
+            } catch (Exception e) {
+                logger().error("An error occurred when closing a failed process for conversation_id: {}",
+                               ehrExtractStatus.getConversationId(), e);
+            }
+        });
     }
 
     public EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAcknowledgementError(String conversationId,
@@ -501,8 +501,8 @@ public class EhrExtractStatusService {
                 conversationId));
         }
 
-        logger().info("EHR status (EHR received acknowledgement) record successfully " +
-                    "updated in the database with error information conversation_id: {}", conversationId);
+        logger().info("EHR status (EHR received acknowledgement) record successfully "
+                    + "updated in the database with error information conversation_id: {}", conversationId);
 
         return ehrExtractStatus;
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -472,9 +472,7 @@ public class EhrExtractStatusService {
 
         ehrExtractStatusList.stream().forEach(ehrExtractStatus -> {
             try {
-                updateEhrExtractStatusWithEhrReceivedAcknowledgementError(ehrExtractStatus.getConversationId(),
-                                                                          errorCode,
-                                                                          errorMessage);
+                updateEhrExtractStatusWithEhrReceivedAckError(ehrExtractStatus.getConversationId(), errorCode, errorMessage);
             } catch (Exception e) {
                 logger().error("An error occurred when closing a failed process for conversation_id: {}",
                                ehrExtractStatus.getConversationId(), e);
@@ -482,9 +480,9 @@ public class EhrExtractStatusService {
         });
     }
 
-    public EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAcknowledgementError(String conversationId,
-                                                                                      String errorCode,
-                                                                                      String errorMessage) {
+    public EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAckError(String conversationId,
+                                                                          String errorCode,
+                                                                          String errorMessage) {
 
         Update update = createUpdateWithUpdatedAt();
         update.addToSet(RECEIVED_ACK_ERRORS, ErrorDetails.builder().code(errorCode).display(errorMessage).build());

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -677,7 +677,6 @@ public class EhrExtractStatusService {
     private boolean hasAcknowledgementExceededEightDays(String conversationId, Instant ackReceivedTimestamp) {
         var ehrExtractStatus = fetchEhrExtractStatus(conversationId, "ACK");
 
-
         if (ehrExtractStatus.getEhrExtractCorePending() == null) {
             return false;
         }
@@ -691,6 +690,11 @@ public class EhrExtractStatusService {
     public boolean hasLastUpdateExceededEightDays(EhrExtractStatus ehrExtractStatus) {
 
         var now = Instant.now();
+
+        if (ehrExtractStatus.getEhrExtractCorePending() == null) {
+            return false;
+        }
+
         Duration duration = Duration.between(ehrExtractStatus.getEhrExtractCorePending().getSentAt(), now);
         long daysSinceLastUpdate = duration.toDays();
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseService.java
@@ -46,17 +46,12 @@ public class EhrStatusBaseService {
         var errorOptional = Optional.ofNullable(ehrExtractStatus.getError());
         var receivedAcknowledgementOptional = Optional.ofNullable(ehrExtractStatus.getEhrReceivedAcknowledgement());
 
-        if (ackPendingOptional.map(ackPending -> ackPending.getTypeCode().equals(NACK_TYPE_CODE)).orElse(false)
+        if (ackPendingOptional.map(ackPending -> NACK_TYPE_CODE.equals(ackPending.getTypeCode())).orElse(false)
             && errorOptional.isPresent()) {
             return FAILED_NME;
-        } else if (ackPendingOptional
-                            .map(ackPending -> ACK_TYPE_CODE.equals(ackPending.getTypeCode())).orElse(false)
-
-                    && ackToRequestorOptional
-                            .map(ackToRequester -> ACK_TYPE_CODE.equals(ackToRequester.getTypeCode())).orElse(false)
-
+        } else if (ackPendingOptional.map(ackPending -> ACK_TYPE_CODE.equals(ackPending.getTypeCode())).orElse(false)
+                    && ackToRequestorOptional.map(ackToRequester -> ACK_TYPE_CODE.equals(ackToRequester.getTypeCode())).orElse(false)
                     && errorOptional.isEmpty()
-
                     && receivedAcknowledgementOptional
                     .map(acknowledgement ->
                         Optional.ofNullable(acknowledgement.getConversationClosed()).isPresent()

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusService.java
@@ -16,9 +16,6 @@ import uk.nhs.adaptors.gp2gp.ehr.status.model.EhrStatus;
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class EhrStatusService extends EhrStatusBaseService {
 
-    private static final String ACK_TYPE_CODE = "AA";
-    private static final String NACK_TYPE_CODE = "AE";
-
     private EhrExtractStatusRepository ehrExtractStatusRepository;
 
     public Optional<EhrStatus> getEhrStatus(String conversationId) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -62,3 +62,5 @@ gp2gp:
       min-back-off: ${GP2GP_MHS_CLIENT_MIN_BACKOFF_SECONDS:5}
       timeout: ${GP2GP_MHS_CLIENT_TIMEOUT_SECONDS:120}
 
+timeout:
+  cronTime: ${TIMEOUT_CRON_TIME:0 0 */2 * * *}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -63,4 +63,4 @@ gp2gp:
       timeout: ${GP2GP_MHS_CLIENT_TIMEOUT_SECONDS:120}
 
 timeout:
-  cronTime: ${TIMEOUT_CRON_TIME:0 0 */2 * * *}
+  cronTime: ${TIMEOUT_CRON_TIME:0 0 */12 * * *}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -364,13 +364,13 @@ class EhrExtractStatusServiceTest {
     }
 
     @Test
-    void receiveUnrecognisedInteractionIdExceptionWhenAcknowledgementReceivedAfter8DaysAndEhrExtractStatusIsNull() {
+    void receiveUnrecognisedInteractionIdExceptionWhenAcknowledgementReceivedAfter8DaysAndEhrExtractStatusIsEmpty() {
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
         String conversationId = generateRandomUppercaseUUID();
         Instant currentInstant = Instant.now();
 
         doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
-        doReturn(null).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+        doReturn(Optional.empty()).when(ehrExtractStatusRepository).findByConversationId(conversationId);
         when(ack.getErrors()).thenReturn(null);
         when(ack.getReceived()).thenReturn(currentInstant);
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -166,7 +166,8 @@ class EhrExtractStatusServiceTest {
 
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
-        verify(logger, times(1)).warn("Received an ACK message with a conversation_id=11111 that is a duplicate");
+        verify(logger, times(1))
+                .warn("Received an ACK message with a conversation_id: {} that is a duplicate", conversationId);
     }
 
     @Test
@@ -199,7 +200,7 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
         verify(logger, times(1))
-            .info("Database successfully updated with EHRAcknowledgement, conversation_id: " + conversationId);
+            .info("Database successfully updated with EHRAcknowledgement, conversation_id: {}", conversationId);
     }
 
     @Test
@@ -233,13 +234,13 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
         verify(logger, times(1))
-            .warn("Received an ACK message with a conversation_id: 11111, but it will be ignored.");
+            .warn("Received an ACK message with a conversation_id: {}, but it will be ignored.", conversationId);
     }
 
     @Test
     void shouldIgnore8DaysLimitWhenExtractCorePendingIsNull() {
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
-        String conversationId = "11111";
+        String conversationId = generateRandomUppercaseUUID();
         Instant currentInstant = Instant.now();
         Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
 
@@ -264,7 +265,7 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
         verify(logger, times(1))
-            .warn("Received an ACK message with a conversation_id=11111 that is a duplicate");
+            .warn("Received an ACK message with a conversation_id: {} that is a duplicate", conversationId);
     }
 
     @Test
@@ -292,7 +293,8 @@ class EhrExtractStatusServiceTest {
 
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
-        verify(logger, times(1)).warn("Received an ACK message with a conversation_id=11111 that is a duplicate");
+        verify(logger, times(1))
+            .warn("Received an ACK message with a conversation_id: {} that is a duplicate", conversationId);
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -81,9 +81,7 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
         verify(ehrExtractStatusServiceSpy, times(1))
-            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus),
-                                                                           ERROR_CODE,
-                                                                           ERROR_MESSAGE);
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
     }
 
     @Test
@@ -181,9 +179,9 @@ class EhrExtractStatusServiceTest {
             = Optional.of(EhrExtractStatus.builder()
                               .updatedAt(eightDaysAgo)
                               .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
-                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
-                                                         .taskId(generateRandomUppercaseUUID())
-                                                         .build())
+                                                                     .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                                     .taskId(generateRandomUppercaseUUID())
+                                                                     .build())
                               .ehrReceivedAcknowledgement(null)
                               .build());
 
@@ -214,15 +212,15 @@ class EhrExtractStatusServiceTest {
             = Optional.of(EhrExtractStatus.builder()
                               .updatedAt(eightDaysAgo)
                               .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
-                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
-                                                         .taskId(generateRandomUppercaseUUID())
-                                                         .build())
+                                                                     .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                                     .taskId(generateRandomUppercaseUUID())
+                                                                     .build())
                               .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().errors(List.of(
-                                  EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails
-                                      .builder()
-                                      .code(ERROR_CODE)
-                                      .display(ERROR_MESSAGE)
-                                      .build())).build())
+                                                                      EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails
+                                                                                      .builder()
+                                                                                      .code(ERROR_CODE)
+                                                                                      .display(ERROR_MESSAGE)
+                                                                                      .build())).build())
                               .build());
 
         doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
@@ -279,9 +277,9 @@ class EhrExtractStatusServiceTest {
             = Optional.of(EhrExtractStatus.builder()
                               .updatedAt(eightDaysAgo)
                               .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
-                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
-                                                         .taskId(generateRandomUppercaseUUID())
-                                                         .build())
+                                                                     .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                                     .taskId(generateRandomUppercaseUUID())
+                                                                     .build())
                               .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().build())
                               .build());
 
@@ -325,22 +323,22 @@ class EhrExtractStatusServiceTest {
             .conversationId(conversationId)
             .created(Instant.now().minus(Duration.ofDays(TWENTY_DAYS)))
             .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
-                                .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
-                                .build())
+                                            .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                            .build())
             .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
-                                       .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
-                                       .taskId(generateRandomUppercaseUUID())
-                                       .build())
+                                                   .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                                   .taskId(generateRandomUppercaseUUID())
+                                                   .build())
             .ehrExtractMessageId(generateRandomUppercaseUUID())
             .ehrRequest(buildEhrRequest())
             .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
                                    .documents(List.of())
                                    .build())
             .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
-                                     .accessedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
-                                     .objectName(generateRandomUppercaseUUID() + ".json")
-                                     .taskId(generateRandomUppercaseUUID())
-                                     .build())
+                                                 .accessedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                                 .objectName(generateRandomUppercaseUUID() + ".json")
+                                                 .taskId(generateRandomUppercaseUUID())
+                                                 .build())
             .messageTimestamp(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
             .updatedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
             .build();

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -6,35 +6,36 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 import uk.nhs.adaptors.gp2gp.common.service.TimestampService;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
-import uk.nhs.adaptors.gp2gp.mhs.exception.UnrecognisedInteractionIdException;
 import java.time.Duration;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
 
 @ExtendWith(MockitoExtension.class)
 class EhrExtractStatusServiceTest {
 
+    private static final Instant NOW = Instant.now();
+    private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
     public static final int NINE_DAYS = 9;
     public static final int EIGHT_DAYS = 8;
-    public static final String ERROR_CODE = "04";
+    public static final String ERROR_CODE = "99";
     public static final String ERROR_MESSAGE = "The acknowledgement has been received after 8 days";
+    public static final String ACK_TYPE = "AA";
+    public static final int TWENTY_DAYS = 20;
+
     @Mock
     private MongoTemplate mongoTemplate;
 
@@ -56,55 +57,40 @@ class EhrExtractStatusServiceTest {
     }
 
     @Test
-    void doesNotUpdateEhrExtractStatusWhenAckDelayExceeds8Days() {
+    public void shouldUpdateStatusWithErrorWhenEhrExtractAckTimeoutOccurs() {
+
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
-        String conversationId = "11111";
-        Instant currentInstant = Instant.now();
-        Instant nineDaysAgo = currentInstant.minus(Duration.ofDays(NINE_DAYS));
-        Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder().updatedAt(nineDaysAgo).build());
+        var inProgressConversationId = generateRandomUppercaseUUID();
 
-        doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
-        doReturn(false).when(ehrExtractStatusServiceSpy).hasFinalAckBeenReceived(conversationId);
-        doReturn(ehrExtractStatus).when(ehrExtractStatusRepository).findByConversationId(conversationId);
-        when(ack.getErrors()).thenReturn(null);
-        when(ack.getReceived()).thenReturn(currentInstant);
-        doReturn(ehrExtractStatus.get())
-            .when(mongoTemplate).findAndModify(any(Query.class), any(Update.class), any(FindAndModifyOptions.class), any(Class.class));
+        EhrExtractStatus ehrExtractStatus = addInProgressTransfers(inProgressConversationId);
 
-        ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
+        doReturn(List.of(ehrExtractStatus)).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
 
-        verify(ehrExtractStatusServiceSpy).updateEhrExtractStatusError(conversationId,
-                                                                       ERROR_CODE,
-                                                                       ERROR_MESSAGE,
-                                                                       ehrExtractStatusServiceSpy.getClass().getSimpleName());
+        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
+
+        verify(ehrExtractStatusServiceSpy, times(1))
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(eq(List.of(ehrExtractStatus)),
+                                                                           eq(ERROR_CODE),
+                                                                           eq(ERROR_MESSAGE));
     }
 
     @Test
-    void ehrExtractStatusThrowsExceptionWhenConversationIdNotFound() {
+    public void shouldNotUpdateStatusWhenNoInProgressTransfersExist() {
+
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
-        String conversationId = "11111";
-        Instant currentInstant = Instant.now();
 
-        doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
-        doReturn(false).when(ehrExtractStatusServiceSpy).hasFinalAckBeenReceived(conversationId);
-        doReturn(Optional.empty()).when(ehrExtractStatusRepository).findByConversationId(conversationId);
-        when(ack.getErrors()).thenReturn(null);
-        when(ack.getReceived()).thenReturn(currentInstant);
+        doReturn(List.of()).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
 
-        Exception exception = assertThrows(UnrecognisedInteractionIdException.class, () ->
-            ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack));
+        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
-        assertEquals("Received an unrecognized ACK message with conversation_id: " + conversationId,
-                     exception.getMessage());
-
-        verify(ehrExtractStatusServiceSpy, never()).updateEhrExtractStatusError(conversationId,
-                                                                       ERROR_CODE,
-                                                                       ERROR_MESSAGE,
-                                                                       ehrExtractStatusServiceSpy.getClass().getSimpleName());
+        verify(ehrExtractStatusServiceSpy, never())
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(eq(List.of()),
+                                                                           eq(ERROR_CODE),
+                                                                           eq(ERROR_MESSAGE));
     }
 
     @Test
-    void updateEhrExtractWhenDelayBewteenAckUpdatesIsLessThan8Days() {
+    void updateEhrExtractWithDelayWithin8Days() {
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
         String conversationId = "11111";
         Instant currentInstant = Instant.now();
@@ -119,7 +105,7 @@ class EhrExtractStatusServiceTest {
         verify(ehrExtractStatusServiceSpy, never()).updateEhrExtractStatusError(conversationId,
                                                                                 ERROR_CODE,
                                                                                 ERROR_MESSAGE,
-                                                                       ehrExtractStatusServiceSpy.getClass().getSimpleName());
+                                                                                ehrExtractStatusServiceSpy.getClass().getSimpleName());
     }
 
     @Test
@@ -137,6 +123,66 @@ class EhrExtractStatusServiceTest {
         var ehrExtractStatusResult = ehrExtractStatusServiceSpy.updateEhrExtractStatusContinue(conversationId);
 
         assertFalse(ehrExtractStatusResult.isPresent());
+    }
+
+    private String generateRandomUppercaseUUID() {
+        return UUID.randomUUID().toString().toUpperCase();
+    }
+
+    private EhrExtractStatus addInProgressTransfers(String conversationId) {
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackPending(buildPositiveAckPending())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(conversationId)
+            .created(Instant.now().minus(Duration.ofDays(TWENTY_DAYS)))
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                                .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                       .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                       .taskId(generateRandomUppercaseUUID())
+                                       .build())
+            .ehrExtractMessageId(generateRandomUppercaseUUID())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                                   .documents(List.of())
+                                   .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                                     .accessedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                     .objectName(generateRandomUppercaseUUID() + ".json")
+                                     .taskId(generateRandomUppercaseUUID())
+                                     .build())
+            .messageTimestamp(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .updatedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .build();
+
+        ehrExtractStatusRepository.save(extractStatus);
+        return extractStatus;
+    }
+
+    private EhrExtractStatus.AckPending buildPositiveAckPending() {
+        return EhrExtractStatus.AckPending.builder()
+            .messageId(generateRandomUppercaseUUID())
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .updatedAt(FIVE_DAYS_AGO.toString())
+            .build();
+    }
+
+    private EhrExtractStatus.AckToRequester buildPositiveAckToRequester() {
+        return EhrExtractStatus.AckToRequester.builder()
+            .detail(null)
+            .messageId(generateRandomUppercaseUUID())
+            .reasonCode(null)
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .build();
+    }
+
+    private EhrExtractStatus.EhrRequest buildEhrRequest() {
+        return EhrExtractStatus.EhrRequest.builder()
+            .messageId(generateRandomUppercaseUUID())
+            .build();
     }
 
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
@@ -7,7 +7,9 @@ import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.ERROR;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.ORIGINAL_FILE;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.PLACEHOLDER;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.SKELETON_MESSAGE;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.COMPLETE;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_INCUMBENT;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_NME;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -30,6 +32,7 @@ public class EhrStatusBaseServiceTest {
 
     public static final int TWENTY_DAYS = 20;
     public static final String ACK_TYPE = "AA";
+    private static final String NACK_TYPE = "AE";
     private static final Instant NOW = Instant.now();
     private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
     public static final int NINE_DAYS = 9;
@@ -119,6 +122,28 @@ public class EhrStatusBaseServiceTest {
         assertEquals(FAILED_INCUMBENT, migrationStatus);
     }
 
+    @Test
+    void evaluateMigrationStatusResolvesToComplete() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = completeTransfers(conversationId);
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
+
+        assertEquals(COMPLETE, migrationStatus);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToFailedNme() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = inProgressTransfers(conversationId);
+        ehrExtractStatus.getAckPending().setTypeCode(NACK_TYPE);
+        ehrExtractStatus.setError(EhrExtractStatus.Error.builder().build());
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
+
+        assertEquals(FAILED_NME, migrationStatus);
+    }
+
     private String generateRandomUppercaseUUID() {
         return UUID.randomUUID().toString().toUpperCase();
     }
@@ -155,6 +180,40 @@ public class EhrStatusBaseServiceTest {
                                                 .code(ERROR_CODE)
                                                 .display(DISPLAY_ERROR_MESSAGE)
                                                 .build())).build())
+            .build();
+
+        return extractStatus;
+    }
+
+    private EhrExtractStatus completeTransfers(String conversationId) {
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackPending(buildPositiveAckPending())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(conversationId)
+            .created(Instant.now().minus(Duration.ofDays(TWENTY_DAYS)))
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                                .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                       .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                       .taskId(generateRandomUppercaseUUID())
+                                       .build())
+            .ehrExtractMessageId(generateRandomUppercaseUUID())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                                   .documents(List.of())
+                                   .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                                     .accessedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                     .objectName(generateRandomUppercaseUUID() + ".json")
+                                     .taskId(generateRandomUppercaseUUID())
+                                     .build())
+            .messageTimestamp(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .updatedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .ehrReceivedAcknowledgement(
+                EhrExtractStatus.EhrReceivedAcknowledgement.builder()
+                    .conversationClosed(FIVE_DAYS_AGO)
+                    .build())
             .build();
 
         return extractStatus;

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
@@ -40,6 +40,7 @@ public class EhrStatusBaseServiceTest {
     private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
     public static final int NINE_DAYS = 9;
     public static final String DISPLAY_ERROR_MESSAGE = "The acknowledgement has been received after 8 days";
+    public static final String ERROR_CODE = "99";
 
     private static final EhrExtractStatus.GpcDocument SKELETON_DOCUMENT = EhrExtractStatus.GpcDocument.builder()
         .isSkeleton(true)
@@ -72,11 +73,11 @@ public class EhrStatusBaseServiceTest {
                 .display("Test Error")
                 .build()))
             .build()
-                                                                                                        );
-    public static final String ERROR_CODE = "99";
+    );
 
     @Mock
     private EhrExtractStatusRepository extractStatusRepository;
+
     @InjectMocks
     private EhrStatusBaseService ehrStatusBaseService;
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
@@ -10,6 +10,7 @@ import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.SKELETON_MESSAGE
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.COMPLETE;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_INCUMBENT;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_NME;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.IN_PROGRESS;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -120,6 +121,17 @@ public class EhrStatusBaseServiceTest {
         MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
 
         assertEquals(FAILED_INCUMBENT, migrationStatus);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToInProgress() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = inProgressTransfers(conversationId);
+        ehrExtractStatus.setEhrReceivedAcknowledgement(null);
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
+
+        assertEquals(IN_PROGRESS, migrationStatus);
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
@@ -8,12 +8,13 @@ import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.ORIGINAL_FILE;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.PLACEHOLDER;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.SKELETON_MESSAGE;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.COMPLETE;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.COMPLETE_WITH_ISSUES;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_INCUMBENT;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_NME;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.IN_PROGRESS;
-
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusRepository;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+import uk.nhs.adaptors.gp2gp.ehr.status.model.EhrStatus;
 import uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus;
 import uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus;
 
@@ -142,6 +144,20 @@ public class EhrStatusBaseServiceTest {
         MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
 
         assertEquals(COMPLETE, migrationStatus);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToCompleteWithIssues() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = completeTransfers(conversationId);
+
+        List<EhrStatus.AttachmentStatus> attachmentStatusList = new ArrayList<>();
+        attachmentStatusList.add(
+            EhrStatus.AttachmentStatus.builder().fileStatus(PLACEHOLDER).build());
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, attachmentStatusList);
+
+        assertEquals(COMPLETE_WITH_ISSUES, migrationStatus);
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
@@ -82,35 +82,35 @@ public class EhrStatusBaseServiceTest {
     private EhrStatusBaseService ehrStatusBaseService;
 
     @Test
-    public void When_GetFileStatus_WithSkeleton_Expect_SkeletonStatus() {
+    void When_GetFileStatus_WithSkeleton_Expect_SkeletonStatus() {
         FileStatus fileStatus = ehrStatusBaseService.getFileStatus(SKELETON_DOCUMENT, List.of());
 
         assertThat(fileStatus).isEqualTo(SKELETON_MESSAGE);
     }
 
     @Test
-    public void When_GetFileStatus_WithAbsentAttachmentInFilename_Expect_PlaceholderStatus() {
+    void When_GetFileStatus_WithAbsentAttachmentInFilename_Expect_PlaceholderStatus() {
         FileStatus fileStatus = ehrStatusBaseService.getFileStatus(PLACEHOLDER_DOCUMENT_1, List.of());
 
         assertThat(fileStatus).isEqualTo(PLACEHOLDER);
     }
 
     @Test
-    public void When_GetFileStatus_WithAbsentAttachmentInObjectName_Expect_PlaceholderStatus() {
+    void When_GetFileStatus_WithAbsentAttachmentInObjectName_Expect_PlaceholderStatus() {
         FileStatus fileStatus = ehrStatusBaseService.getFileStatus(PLACEHOLDER_DOCUMENT_2, List.of());
 
         assertThat(fileStatus).isEqualTo(PLACEHOLDER);
     }
 
     @Test
-    public void When_GetFileStatus_WithNoErrorOrPlaceholder_Expect_OriginalFileStatus() {
+    void When_GetFileStatus_WithNoErrorOrPlaceholder_Expect_OriginalFileStatus() {
         FileStatus fileStatus = ehrStatusBaseService.getFileStatus(ORIGINAL_FILE_DOCUMENT, List.of());
 
         assertThat(fileStatus).isEqualTo(ORIGINAL_FILE);
     }
 
     @Test
-    public void When_GetFileStatus_WithNACK_Expect_ErrorStatus() {
+    void When_GetFileStatus_WithNACK_Expect_ErrorStatus() {
         FileStatus fileStatus = ehrStatusBaseService.getFileStatus(ORIGINAL_FILE_DOCUMENT, ONE_FAILED_ACK_LIST);
 
         assertThat(fileStatus).isEqualTo(ERROR);


### PR DESCRIPTION
## What

Scheduler delay checker was added.

## Why

The scheduler delay checker now marks transfer requests as failed if they exceed the 8-day limit without receiving a final acknowledgment.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
