### PR TITLE
NIAD-3150: Add confidentialityCode to MedicationStatements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ will contain a `NOPAT` `confidentialityCode` element.
   for that resource will contain a `NOPAT` `confidentialityCode` element.
 * When mapping a `Condition` which contains a `NOPAT` `meta.security` tag the resultant XML for that resource
   will contain a `NOPAT` `confidentialityCode` element.
-
+* When mapping a `MedicationRequest (PLAN)` which contains a `NOPAT` `meta.security` tag the resultant XML for that 
+resource will contain a `NOPAT` `confidentialityCode` element.
+* When mapping a `MedicationRequest (ORDER)` which contains a `NOPAT` `meta.security` tag the resultant XML for that
+resource will contain a `NOPAT` `confidentialityCode` element.
 ## [2.0.6] - 2024-07-29
 
 ### Added

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
@@ -1,8 +1,25 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import com.github.mustachejava.Mustache;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractDispenseRequestQuantityText;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractDispenseRequestQuantityTextFromQuantity;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractEhrSupplyTypeCodeableConcept;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractIdFromPlanMedicationRequestReference;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractPrescriptionTypeCode;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractRepeatValue;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedAvailabilityTime;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedCode;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedText;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.hasStatusReasonStopped;
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.prescriptionTypeTextIsNoInfoAvailable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.Annotation;
 import org.hl7.fhir.dstu3.model.Medication;
@@ -15,32 +32,17 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
+
+import com.github.mustachejava.Mustache;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.MedicationStatementTemplateParameters;
 import uk.nhs.adaptors.gp2gp.ehr.utils.StatementTimeMappingUtils;
 import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
 import uk.nhs.adaptors.gp2gp.ehr.utils.UnitsOfTimeMappingUtils;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractDispenseRequestQuantityText;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractDispenseRequestQuantityTextFromQuantity;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractEhrSupplyTypeCodeableConcept;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractIdFromPlanMedicationRequestReference;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractPrescriptionTypeCode;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractRepeatValue;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedAvailabilityTime;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedCode;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.extractStatusReasonStoppedText;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.hasStatusReasonStopped;
-import static uk.nhs.adaptors.gp2gp.ehr.mapper.MedicationStatementExtractor.prescriptionTypeTextIsNoInfoAvailable;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Component

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/MedicationStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/MedicationStatementTemplateParameters.java
@@ -12,6 +12,7 @@ public class MedicationStatementTemplateParameters {
     private String statusCode;
     private String effectiveTime;
     private String availabilityTime;
+    private String confidentialityCode;
     private String medicationReferenceCode;
     private String ehrSupplyId;
     private String medicationStatementPertinentInformation;

--- a/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
@@ -8,6 +8,9 @@
         </effectiveTime>
         {{/effectiveTime}}
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         <consumable typeCode="CSM">
             <manufacturedProduct classCode="MANU">
                 <manufacturedMaterial determinerCode="KIND" classCode="MMAT">

--- a/service/src/main/resources/templates/ehr_medication_statement_prescribe_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_prescribe_template.mustache
@@ -8,6 +8,9 @@
         </effectiveTime>
         {{/effectiveTime}}
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         <consumable typeCode="CSM">
             <manufacturedProduct classCode="MANU">
                 <manufacturedMaterial determinerCode="KIND" classCode="MMAT">

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -170,7 +170,13 @@ public class EhrExtractMapperComponentTest {
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
             new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
-            new MedicationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, randomIdGeneratorService),
+            new MedicationStatementMapper(
+                messageContext,
+                codeableConceptCdMapper,
+                participantMapper,
+                randomIdGeneratorService,
+                confidentialityService
+            ),
             new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
             new ObservationStatementMapper(
                 messageContext,

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -169,7 +169,12 @@ public class EhrExtractMapperComponentTest {
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
-            new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new ImmunizationObservationStatementMapper(
+                messageContext,
+                codeableConceptCdMapper,
+                participantMapper,
+                confidentialityService
+            ),
             new MedicationStatementMapper(
                 messageContext,
                 codeableConceptCdMapper,
@@ -177,13 +182,6 @@ public class EhrExtractMapperComponentTest {
                 randomIdGeneratorService,
                 confidentialityService
             ),
-            new ImmunizationObservationStatementMapper(
-                messageContext,
-                codeableConceptCdMapper,
-                participantMapper,
-                confidentialityService
-            ),
-            new MedicationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, randomIdGeneratorService),
             new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
             new ObservationStatementMapper(
                 messageContext,

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -1,17 +1,5 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.when;
-
-import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
-
-import java.util.List;
-import java.util.stream.Stream;
-
 import org.hl7.fhir.dstu3.model.AllergyIntolerance;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
@@ -29,7 +17,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
@@ -43,6 +30,17 @@ import uk.nhs.adaptors.gp2gp.ehr.utils.BloodPressureValidator;
 import uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils;
 import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EncounterComponentsMapperTest {
@@ -152,8 +150,13 @@ public class EncounterComponentsMapperTest {
         DocumentReferenceToNarrativeStatementMapper documentReferenceToNarrativeStatementMapper
             = new DocumentReferenceToNarrativeStatementMapper(
                 messageContext, new SupportedContentTypes(), timestampService, participantMapper);
-        MedicationStatementMapper medicationStatementMapper
-            = new MedicationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, randomIdGeneratorService);
+        MedicationStatementMapper medicationStatementMapper = new MedicationStatementMapper(
+            messageContext,
+            codeableConceptCdMapper,
+            participantMapper,
+            randomIdGeneratorService,
+            confidentialityService
+        );
         ObservationToNarrativeStatementMapper observationToNarrativeStatementMapper =
             new ObservationToNarrativeStatementMapper(messageContext, participantMapper);
         SpecimenMapper specimenMapper = getSpecimenMapper(structuredObservationValueMapper, participantMapper);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
@@ -1,6 +1,19 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import lombok.SneakyThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.MedicationRequest;
 import org.hl7.fhir.dstu3.model.Reference;
@@ -18,24 +31,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+
+import lombok.SneakyThrows;
 import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.nhs.adaptors.gp2gp.utils.IdUtil.buildIdType;
 
 @ExtendWith(MockitoExtension.class)
 public class MedicationStatementMapperTest {
@@ -272,7 +274,7 @@ public class MedicationStatementMapperTest {
 
     @ParameterizedTest
     @MethodSource("resourceFileExpectException")
-    public void When_MappingMedicationRequestWithInvalidResource_Expect_Exception(String inputJson) {
+    public void When_MappingMedicationRequestWithInvalidResource_Expect_Exception(String inputJson) throws IOException {
         var jsonInput = ResourceTestFileUtils.getFileContent(inputJson);
         MedicationRequest parsedMedicationRequest = new FhirParseService().parseResource(jsonInput, MedicationRequest.class);
 
@@ -298,7 +300,7 @@ public class MedicationStatementMapperTest {
     }
 
     @Test
-    public void When_MappingMedicationRequestWithRequesterWithOnBehalfOf_Expect_ParticipantMappedToAgent() {
+    public void When_MappingMedicationRequestWithRequesterWithOnBehalfOf_Expect_ParticipantMappedToAgent() throws IOException {
         when(mockRandomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
         codeableConceptCdMapper = new CodeableConceptCdMapper();
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
@@ -346,9 +348,7 @@ public class MedicationStatementMapperTest {
     @ParameterizedTest
     @MethodSource("resourceFilesWithParticipant")
     public void When_MappingMedicationRequestWithParticipant_Expect_ParticipantMappedToAgent(
-        String inputJson,
-        String agentId
-    ) {
+        String inputJson, String agentId) throws IOException {
         when(mockRandomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
         codeableConceptCdMapper = new CodeableConceptCdMapper();
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
@@ -395,7 +395,7 @@ public class MedicationStatementMapperTest {
     @ParameterizedTest
     @MethodSource("resourceFilesWithMedicationStatement")
     public void When_MappingMedicationRequest_WithMedicationStatement_Expect_PrescribingAgencyMappedToSupplyType(
-        String inputJson, String outputXml) {
+        String inputJson, String outputXml) throws IOException {
 
         var expected = ResourceTestFileUtils.getFileContent(outputXml);
 
@@ -484,6 +484,5 @@ public class MedicationStatementMapperTest {
         assertThat(diff.hasDifferences())
             .as("Xml is not equal: " + System.lineSeparator() + diff.fullDescription())
             .isFalse();
-
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -189,7 +189,12 @@ public class EhrExtractUATTest {
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
-            new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new ImmunizationObservationStatementMapper(
+                messageContext,
+                codeableConceptCdMapper,
+                participantMapper,
+                confidentialityService
+            ),
             new MedicationStatementMapper(
                 messageContext,
                 codeableConceptCdMapper,
@@ -197,13 +202,6 @@ public class EhrExtractUATTest {
                 randomIdGeneratorService,
                 confidentialityService
             ),
-            new ImmunizationObservationStatementMapper(
-                messageContext,
-                codeableConceptCdMapper,
-                participantMapper,
-                confidentialityService
-            ),
-            new MedicationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, randomIdGeneratorService),
             new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
             new ObservationStatementMapper(
                 messageContext,

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -190,7 +190,13 @@ public class EhrExtractUATTest {
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
             documentReferenceToNarrativeStatementMapper,
             new ImmunizationObservationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
-            new MedicationStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, randomIdGeneratorService),
+            new MedicationStatementMapper(
+                messageContext,
+                codeableConceptCdMapper,
+                participantMapper,
+                randomIdGeneratorService,
+                confidentialityService
+            ),
             new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
             new ObservationStatementMapper(
                 messageContext,


### PR DESCRIPTION
## What

* Add functionality to provide `confidentialityCode` for both `PLAN` and `ORDER` when mapping `MedicationRequests` which contain a `NOPAT` `meta.security` tag. 
* Add Unit Tests to MedicationStatementMapperTest to test mapping of `confidentialityCode` when present or not present for both `supplyPrescribe` and `supplyAuthorise`.
* Update MedicationStatementMapper to inject ConfidentialityService and to add parameter for `confidentialityCode` to MedicationStatementTemplateParameters.
* Update mustache template to include mapping for confidentialityCode for both `PLAN` and `ORDER`. 
* Update injection of ConfidentialityService in related test files.
* Update CHANGELOG.md

## Why

A requirement for the Redactions work is to add NOPAT confidentialityCode handling to `MedicationRequests`:

_GP2GP Adaptor populates the MedicationStatement / confidentialityCode field when the MedicationRequest.meta.security field is populated with NOPAT and the message type is RCMR_IN030000UK07._

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
