### PR TITLE
NIAD-2840: Identifies no acknowledgment after 8 Days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Added a scheduled delay checker to update EhrExtract to "Integration Failure" state if sentAt exceeds 192 hours and no acknowledgment is received. 
+* Added a scheduled delay checker to update EhrExtract to "Integration Failure" state if sentAt exceeds 8 days and no acknowledgment is received. 
 
 ### Added
 

--- a/service/src/intTest/resources/application.yml
+++ b/service/src/intTest/resources/application.yml
@@ -68,3 +68,6 @@ gp2gp:
       max-backoff-attempts: 3
       min-back-off: 2
       timeout: 3
+
+timeout:
+  cronTime: ${TIMEOUT_CRON_TIME:0 0 */12 * * *}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/configuration/Gp2gpConfiguration.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/configuration/Gp2gpConfiguration.java
@@ -5,10 +5,12 @@ import org.springframework.context.annotation.Configuration;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Getter
 @Setter
 @Configuration
+@EnableScheduling
 @ConfigurationProperties(prefix = "gp2gp")
 public class Gp2gpConfiguration {
     private int largeAttachmentThreshold;

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -142,7 +142,7 @@ public class EhrExtractStatusService {
         }
     }
 
-    boolean hasEhrStatusReceivedAckWithErrors(String conversationId) {
+    boolean hasEhrStatusReceivedAckWithUnexpectedConditionErrors(String conversationId) {
 
         var ehrExtractStatus = fetchEhrExtractStatus(conversationId, "NACK");
 
@@ -402,7 +402,7 @@ public class EhrExtractStatusService {
         }
 
         if (hasAcknowledgementExceededEightDays(conversationId, ack.getReceived())
-            && hasEhrStatusReceivedAckWithErrors(conversationId)) {
+            && hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId)) {
 
             logger().warn("Received an ACK message with a conversation_id: {}, but it will be ignored", conversationId);
             return;

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -407,6 +407,7 @@ public class EhrExtractStatusService {
                                         REASON_ERROR_CODE,
                                         REASON_ERROR_MESSAGE,
                                         this.getClass().getSimpleName());
+            logger().warn("Received an ACK message with a conversation_id=" + conversationId + " exceeded 8 days");
             return;
         }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -211,8 +211,7 @@ public class EhrExtractStatusService {
             return false;
         }
 
-        Duration duration = Duration.between(ehrExtractStatus.getEhrExtractCorePending().getSentAt(), time);
-        long daysSinceLastUpdate = duration.toDays();
+        long daysSinceLastUpdate = Duration.between(ehrExtractStatus.getEhrExtractCorePending().getSentAt(), time).toDays();
 
         return daysSinceLastUpdate > EHR_EXTRACT_SENT_DAYS_LIMIT;
     }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -132,14 +133,11 @@ public class EhrExtractStatusService {
         var ehrExtractStatusWithExceededUpdateLimit = inProgressEhrExtractTransfers
             .stream()
             .filter(ehrExtractStatus -> Objects.isNull(ehrExtractStatus.getEhrReceivedAcknowledgement()))
-            .filter(ehrExtractStatus -> hasLastUpdateExceededEightDays(ehrExtractStatus, now))
-            .toList();
+            .filter(ehrExtractStatus -> hasLastUpdateExceededEightDays(ehrExtractStatus, now));
 
-        if (!ehrExtractStatusWithExceededUpdateLimit.isEmpty()) {
-            updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(ehrExtractStatusWithExceededUpdateLimit,
-                                                                          UNEXPECTED_CONDITION_ERROR_CODE,
-                                                                          UNEXPECTED_CONDITION_ERROR_MESSAGE);
-        }
+        updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(ehrExtractStatusWithExceededUpdateLimit,
+                                                                      UNEXPECTED_CONDITION_ERROR_CODE,
+                                                                      UNEXPECTED_CONDITION_ERROR_MESSAGE);
     }
 
     boolean hasEhrStatusReceivedAckWithUnexpectedConditionErrors(String conversationId) {
@@ -164,11 +162,11 @@ public class EhrExtractStatusService {
         return ehrReceivedAckErrorDetailsThatContainsSearchedErrCodeAndMsg.isPresent();
     }
 
-    void updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List<EhrExtractStatus> ehrExtractStatusList,
+    void updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(Stream<EhrExtractStatus> ehrExtractStatusList,
                                                                        String errorCode,
                                                                        String errorMessage) {
 
-        ehrExtractStatusList.stream().forEach(ehrExtractStatus -> {
+        ehrExtractStatusList.forEach(ehrExtractStatus -> {
             try {
                 updateEhrExtractStatusWithEhrReceivedAckError(ehrExtractStatus.getConversationId(), errorCode, errorMessage);
             } catch (EhrExtractException exception) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -173,16 +173,12 @@ public class EhrExtractStatusService {
 
                 logger().error("An error occurred when closing a failed process for conversation_id: {}",
                                ehrExtractStatus.getConversationId(), e);
-
-                if (e instanceof EhrExtractException) {
-                    throw e;
-                }
-
+                throw e;
             }
         });
     }
 
-    private EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAckError(String conversationId,
+    private void updateEhrExtractStatusWithEhrReceivedAckError(String conversationId,
                                                                            String errorCode,
                                                                            String errorMessage) {
 
@@ -204,7 +200,6 @@ public class EhrExtractStatusService {
         logger().info("EHR status (EHR received acknowledgement) record successfully "
                       + "updated in the database with error information conversation_id: {}", conversationId);
 
-        return ehrExtractStatus;
     }
 
     public boolean hasLastUpdateExceededEightDays(EhrExtractStatus ehrExtractStatus) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -397,17 +397,15 @@ public class EhrExtractStatusService {
             return;
         }
 
-        if (hasFinalAckBeenReceived(conversationId)) {
-            logger().warn("Received an ACK message with a conversation_id=" + conversationId + " that is a duplicate");
+        if (hasAcknowledgementExceededEightDays(conversationId, ack.getReceived())
+            && hasEhrStatusReceivedAckWithErrors(conversationId)) {
+
+            logger().warn("Received an ACK message with a conversation_id: {}, but it will be ignored", conversationId);
             return;
         }
 
-        if (hasAcknowledgementExceededEightDays(conversationId, ack.getReceived())) {
-            updateEhrExtractStatusError(conversationId,
-                                        REASON_ERROR_CODE,
-                                        REASON_ERROR_MESSAGE,
-                                        this.getClass().getSimpleName());
-            logger().warn("Received an ACK message with a conversation_id=" + conversationId + " exceeded 8 days");
+        if (hasFinalAckBeenReceived(conversationId)) {
+            logger().warn("Received an ACK message with a conversation_id=" + conversationId + " that is a duplicate");
             return;
         }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -162,23 +162,29 @@ public class EhrExtractStatusService {
         return ehrReceivedAckErrorDetailsThatContainsSearchedErrCodeAndMsg.isPresent();
     }
 
-    public void updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List<EhrExtractStatus> ehrExtractStatusList,
-                                                                              String errorCode,
-                                                                              String errorMessage) {
+    void updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List<EhrExtractStatus> ehrExtractStatusList,
+                                                                       String errorCode,
+                                                                       String errorMessage) {
 
         ehrExtractStatusList.stream().forEach(ehrExtractStatus -> {
             try {
                 updateEhrExtractStatusWithEhrReceivedAckError(ehrExtractStatus.getConversationId(), errorCode, errorMessage);
             } catch (Exception e) {
+
                 logger().error("An error occurred when closing a failed process for conversation_id: {}",
                                ehrExtractStatus.getConversationId(), e);
+
+                if (e instanceof EhrExtractException) {
+                    throw e;
+                }
+
             }
         });
     }
 
-    protected EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAckError(String conversationId,
-                                                                             String errorCode,
-                                                                             String errorMessage) {
+    private EhrExtractStatus updateEhrExtractStatusWithEhrReceivedAckError(String conversationId,
+                                                                           String errorCode,
+                                                                           String errorMessage) {
 
         Update update = createUpdateWithUpdatedAt();
         update.addToSet(RECEIVED_ACK_ERRORS, ErrorDetails.builder().code(errorCode).display(errorMessage).build());

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusService.java
@@ -16,9 +16,6 @@ import uk.nhs.adaptors.gp2gp.ehr.status.model.EhrStatus;
 @AllArgsConstructor(onConstructor = @__(@Autowired))
 public class EhrStatusService extends EhrStatusBaseService {
 
-    private static final String ACK_TYPE_CODE = "AA";
-    private static final String NACK_TYPE_CODE = "AE";
-
     private EhrExtractStatusRepository ehrExtractStatusRepository;
 
     public Optional<EhrStatus> getEhrStatus(String conversationId) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -62,3 +62,6 @@ gp2gp:
       min-back-off: ${GP2GP_MHS_CLIENT_MIN_BACKOFF_SECONDS:5}
       timeout: ${GP2GP_MHS_CLIENT_TIMEOUT_SECONDS:120}
 
+timeout:
+  cronTime: ${TIMEOUT_CRON_TIME:0 0 */12 * * *}
+

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -437,6 +437,10 @@ class EhrExtractStatusServiceTest {
 
         ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
+        verify(ehrExtractStatusServiceSpy, times(1))
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(any(Stream.class),
+                                                                           eq(ERROR_CODE),
+                                                                           eq(ERROR_MESSAGE));
         verify(logger).info("EHR status (EHR received acknowledgement) record successfully "
                                + "updated in the database with error information conversation_id: {}", inProgressConversationId);
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -288,7 +288,7 @@ class EhrExtractStatusServiceTest {
 
         doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
 
-        boolean result = ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId);
+        boolean result = ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId);
 
         assertFalse(result);
     }
@@ -313,7 +313,7 @@ class EhrExtractStatusServiceTest {
 
         doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
 
-        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId));
+        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId));
     }
 
     @Test
@@ -336,7 +336,7 @@ class EhrExtractStatusServiceTest {
 
         doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
 
-        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId));
+        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId));
     }
 
     @Test
@@ -359,7 +359,7 @@ class EhrExtractStatusServiceTest {
 
         doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
 
-        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId));
+        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId));
     }
 
     @Test
@@ -387,7 +387,7 @@ class EhrExtractStatusServiceTest {
 
         doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
 
-        assertDoesNotThrow(() -> ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId));
+        assertDoesNotThrow(() -> ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId));
     }
 
     @Test
@@ -415,7 +415,7 @@ class EhrExtractStatusServiceTest {
 
         doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
 
-        boolean result = ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId);
+        boolean result = ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId);
 
         assertTrue(result);
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -188,6 +188,34 @@ class EhrExtractStatusServiceTest {
     }
 
     @Test
+    void expectNoExceptionWhenEhrExtractStatusWithEhrReceivedAckWithErrorsIncludesNullValue() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var conversationId = generateRandomUppercaseUUID();
+        Instant currentInstant = Instant.now();
+        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
+
+        Optional<EhrExtractStatus> ehrExtractStatusWithEhrReceivedAckWithErrors
+            = Optional.of(EhrExtractStatus.builder()
+                              .updatedAt(eightDaysAgo)
+                              .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                         .taskId(generateRandomUppercaseUUID())
+                                                         .build())
+                              .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().errors(List.of(
+                                  EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails
+                                      .builder()
+                                      .code(null)
+                                      .display(ERROR_MESSAGE)
+                                      .build())).build())
+                              .build());
+
+        doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+
+        assertDoesNotThrow(() -> ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId));
+    }
+
+    @Test
     void expectTrueWhenEhrExtractStatusWithEhrReceivedAckWithErrorsThatMatchExpectedErrorType() {
 
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -11,7 +11,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.core.query.UpdateDefinition;
@@ -54,9 +53,9 @@ class EhrExtractStatusServiceTest {
     public static final int TWENTY_DAYS = 20;
     private static final String RECEIVED_ACK_ERRORS = "ehrReceivedAcknowledgement.errors";
 
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
-    ArgumentCaptor<Class<EhrExtractStatus>> classCaptor = ArgumentCaptor.forClass(Class.class);
+    private ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    private ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    private ArgumentCaptor<Class<EhrExtractStatus>> classCaptor = ArgumentCaptor.forClass(Class.class);
 
     @Mock
     private Logger logger;
@@ -398,11 +397,11 @@ class EhrExtractStatusServiceTest {
                                                                             any(FindAndModifyOptions.class),
                                                                             classCaptor.capture());
 
-        assertEquals(ERROR_CODE, ((EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails)((Document) updateCaptor.getValue()
+        assertEquals(ERROR_CODE, ((EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails) ((Document) updateCaptor.getValue()
                                                                                 .getUpdateObject()
                                                                                 .get("$addToSet"))
                                                                                 .get("ehrReceivedAcknowledgement.errors")).getCode());
-        assertEquals(ERROR_MESSAGE, ((EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails)((Document) updateCaptor.getValue()
+        assertEquals(ERROR_MESSAGE, ((EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails) ((Document) updateCaptor.getValue()
                                                                                 .getUpdateObject()
                                                                                 .get("$addToSet"))
                                                                                 .get("ehrReceivedAcknowledgement.errors")).getDisplay());

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -188,6 +188,52 @@ class EhrExtractStatusServiceTest {
     }
 
     @Test
+    void expectFalseWhenEhrExtractStatusWithEhrReceivedAckWithErrorsIsNull() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var conversationId = generateRandomUppercaseUUID();
+        Instant currentInstant = Instant.now();
+        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
+
+        Optional<EhrExtractStatus> ehrExtractStatusWithEhrReceivedAckWithErrors
+            = Optional.of(EhrExtractStatus.builder()
+                              .updatedAt(eightDaysAgo)
+                              .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                         .taskId(generateRandomUppercaseUUID())
+                                                         .build())
+                              .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().errors(null).build())
+                              .build());
+
+        doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+
+        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId));
+    }
+
+    @Test
+    void expectFalseWhenhrReceivedAckIsNull() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var conversationId = generateRandomUppercaseUUID();
+        Instant currentInstant = Instant.now();
+        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
+
+        Optional<EhrExtractStatus> ehrExtractStatusWithEhrReceivedAckWithErrors
+            = Optional.of(EhrExtractStatus.builder()
+                              .updatedAt(eightDaysAgo)
+                              .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                         .taskId(generateRandomUppercaseUUID())
+                                                         .build())
+                              .ehrReceivedAcknowledgement(null)
+                              .build());
+
+        doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+
+        assertFalse(ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId));
+    }
+
+    @Test
     void expectNoExceptionWhenEhrExtractStatusWithEhrReceivedAckWithErrorsIncludesNullValue() {
 
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -79,7 +79,13 @@ class EhrExtractStatusServiceTest {
         String conversationId = "11111";
         Instant currentInstant = Instant.now();
         Instant nineDaysAgo = currentInstant.minus(Duration.ofDays(NINE_DAYS));
-        Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder().updatedAt(nineDaysAgo).build());
+        Optional<EhrExtractStatus> ehrExtractStatus = Optional.of(EhrExtractStatus.builder()
+                                                                      .ehrExtractCorePending(
+                                                                          EhrExtractStatus.EhrExtractCorePending
+                                                                              .builder()
+                                                                              .sentAt(nineDaysAgo)
+                                                                              .build())
+                                                                      .build());
 
         doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
         doReturn(false).when(ehrExtractStatusServiceSpy).hasFinalAckBeenReceived(conversationId);
@@ -416,9 +422,8 @@ class EhrExtractStatusServiceTest {
                                      () -> ehrExtractStatusServiceSpy.updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(
                                             List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE));
 
-
-        assertEquals("Couldn't update EHR received acknowledgement with error information because EHR status doesn't exist, " +
-                     "conversation_id: " + inProgressConversationId,
+        assertEquals("Couldn't update EHR received acknowledgement with error information because EHR status doesn't exist, "
+                     + "conversation_id: " + inProgressConversationId,
                      exception.getMessage());
         verify(logger).error(eq("An error occurred when closing a failed process for conversation_id: {}"),
                              eq(inProgressConversationId),
@@ -438,11 +443,10 @@ class EhrExtractStatusServiceTest {
                                                          any(FindAndModifyOptions.class), any());
         when(ehrExtractStatusServiceSpy.logger()).thenReturn(logger);
 
-        var exception = assertThrows(EhrExtractException.class,
-                                     () -> ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts());
+        var exception = assertThrows(EhrExtractException.class, () -> ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts());
 
-        assertEquals("Couldn't update EHR received acknowledgement with error information because EHR status doesn't exist, " +
-                     "conversation_id: " + inProgressConversationId,
+        assertEquals("Couldn't update EHR received acknowledgement with error information because EHR status doesn't exist, "
+                     + "conversation_id: " + inProgressConversationId,
                      exception.getMessage());
         verify(logger).error(eq("An error occurred when closing a failed process for conversation_id: {}"),
                              eq(inProgressConversationId),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -262,6 +262,23 @@ class EhrExtractStatusServiceTest {
     }
 
     @Test
+    void shouldNotUpdateStatusWhenEhrReceivedAcknowledgementIsNotNull() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var inProgressConversationId = generateRandomUppercaseUUID();
+
+        EhrExtractStatus ehrExtractStatus = addInProgressTransfers(inProgressConversationId);
+        ehrExtractStatus.setEhrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().build());
+
+        doReturn(List.of(ehrExtractStatus)).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
+
+        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
+
+        verify(ehrExtractStatusServiceSpy, never())
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
+    }
+
+    @Test
     void shouldNotUpdateStatusWhenNoInProgressTransfersExist() {
 
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -51,7 +51,6 @@ class EhrExtractStatusServiceTest {
     private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
     public static final String ACK_TYPE = "AA";
     public static final int TWENTY_DAYS = 20;
-    private static final String RECEIVED_ACK_ERRORS = "ehrReceivedAcknowledgement.errors";
 
     private ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
     private ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
@@ -128,7 +127,7 @@ class EhrExtractStatusServiceTest {
 
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
-        verify(logger, never()).warn("Received an ACK message with a conversation_id={} exceeded 8 days", eq(conversationId));
+        verify(logger, never()).warn("Received an ACK message with a conversation_id={} exceeded 8 days", conversationId);
         verify(logger, times(1))
                             .info("Database successfully updated with EHRAcknowledgement, conversation_id: " + conversationId);
     }
@@ -369,8 +368,7 @@ class EhrExtractStatusServiceTest {
         verify(ehrExtractStatusServiceSpy, times(1))
             .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
         verify(logger).info("EHR status (EHR received acknowledgement) record successfully "
-                               + "updated in the database with error information conversation_id: {}",
-                             eq(inProgressConversationId));
+                               + "updated in the database with error information conversation_id: {}", inProgressConversationId);
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -6,25 +6,34 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import uk.nhs.adaptors.gp2gp.common.service.TimestampService;
+import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 import uk.nhs.adaptors.gp2gp.mhs.exception.UnrecognisedInteractionIdException;
 import java.time.Duration;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,8 +42,17 @@ class EhrExtractStatusServiceTest {
 
     public static final int NINE_DAYS = 9;
     public static final int EIGHT_DAYS = 8;
-    public static final String ERROR_CODE = "04";
+    public static final String ERROR_CODE = "99";
+    public static final String ALTERNATIVE_ERROR_CODE = "26";
     public static final String ERROR_MESSAGE = "The acknowledgement has been received after 8 days";
+    private static final Instant NOW = Instant.now();
+    private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
+    public static final String ACK_TYPE = "AA";
+    public static final int TWENTY_DAYS = 20;
+
+    @Mock
+    private Logger logger;
+
     @Mock
     private MongoTemplate mongoTemplate;
 
@@ -137,6 +155,225 @@ class EhrExtractStatusServiceTest {
         var ehrExtractStatusResult = ehrExtractStatusServiceSpy.updateEhrExtractStatusContinue(conversationId);
 
         assertFalse(ehrExtractStatusResult.isPresent());
+    }
+
+    @Test
+    void expectFalseWhenEhrExtractStatusWithEhrReceivedAckWithErrorsDoesNotMatchExpectedErrorType() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var conversationId = generateRandomUppercaseUUID();
+        Instant currentInstant = Instant.now();
+        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
+
+        Optional<EhrExtractStatus> ehrExtractStatusWithEhrReceivedAckWithErrors
+            = Optional.of(EhrExtractStatus.builder()
+                              .updatedAt(eightDaysAgo)
+                              .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                         .taskId(generateRandomUppercaseUUID())
+                                                         .build())
+                              .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().errors(List.of(
+                                  EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails
+                                      .builder()
+                                      .code(ALTERNATIVE_ERROR_CODE)
+                                      .display(ERROR_MESSAGE)
+                                      .build())).build())
+                              .build());
+
+        doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+
+        boolean result = ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId);
+
+        assertFalse(result);
+    }
+
+    @Test
+    void expectTrueWhenEhrExtractStatusWithEhrReceivedAckWithErrorsThatMatchExpectedErrorType() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var conversationId = generateRandomUppercaseUUID();
+        Instant currentInstant = Instant.now();
+        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
+
+        Optional<EhrExtractStatus> ehrExtractStatusWithEhrReceivedAckWithErrors
+            = Optional.of(EhrExtractStatus.builder()
+                              .updatedAt(eightDaysAgo)
+                              .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                         .taskId(generateRandomUppercaseUUID())
+                                                         .build())
+                              .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().errors(List.of(
+                                  EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails
+                                      .builder()
+                                      .code(ERROR_CODE)
+                                      .display(ERROR_MESSAGE)
+                                      .build())).build())
+                              .build());
+
+        doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+
+        boolean result = ehrExtractStatusServiceSpy.hasEhrStatusReceivedAckWithErrors(conversationId);
+
+        assertTrue(result);
+    }
+
+    @Test
+    void shouldUpdateStatusWithErrorWhenEhrExtractAckTimeoutOccurs() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var inProgressConversationId = generateRandomUppercaseUUID();
+
+        EhrExtractStatus ehrExtractStatus = addInProgressTransfers(inProgressConversationId);
+
+        doReturn(List.of(ehrExtractStatus)).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
+
+        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
+
+        verify(ehrExtractStatusServiceSpy, times(1))
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
+    }
+
+    @Test
+    void shouldNotUpdateStatusWhenNoInProgressTransfersExist() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+
+        doReturn(List.of()).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
+
+        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
+
+        verify(ehrExtractStatusServiceSpy, never())
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(), ERROR_CODE, ERROR_MESSAGE);
+    }
+
+    @Test
+    void shouldNotUpdateStatusWhenInProgressTransfersWithNullEhrExtractCorePendingExist() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var inProgressConversationId = generateRandomUppercaseUUID();
+
+        EhrExtractStatus ehrExtractStatus = addInProgressTransfers(inProgressConversationId);
+        ehrExtractStatus.setEhrExtractCorePending(null);
+
+        doReturn(List.of(ehrExtractStatus)).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
+
+        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
+
+        verify(ehrExtractStatusServiceSpy, never())
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(), ERROR_CODE, ERROR_MESSAGE);
+    }
+
+    @Test
+    void whenEhrExtractStatusIsNullInterceptExceptionAndLogErrorMsg() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var inProgressConversationId = generateRandomUppercaseUUID();
+
+        EhrExtractStatus ehrExtractStatus = addInProgressTransfers(inProgressConversationId);
+
+        doReturn(List.of(ehrExtractStatus)).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
+        doReturn(null).when(mongoTemplate).findAndModify(any(Query.class), any(UpdateDefinition.class),
+                                                         any(FindAndModifyOptions.class), any());
+        when(ehrExtractStatusServiceSpy.logger()).thenReturn(logger);
+
+        assertDoesNotThrow(() -> ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts());
+
+        verify(logger).error(eq("An error occurred when closing a failed process for conversation_id: {}"),
+                             eq(inProgressConversationId),
+                             any(EhrExtractException.class));
+    }
+
+    @Test
+    void shouldLogWarningWithDuplicateWhenLateAcknowledgementReceivedAfter8DaysAndEhrReceivedAckErrorCodeDoNotMatch() {
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        String conversationId = generateRandomUppercaseUUID();
+        Instant currentInstant = Instant.now();
+        Instant eightDaysAgo = currentInstant.minus(Duration.ofDays(EIGHT_DAYS));
+
+        Optional<EhrExtractStatus> ehrExtractStatusWithEhrReceivedAckWithErrors
+            = Optional.of(EhrExtractStatus.builder()
+                              .updatedAt(eightDaysAgo)
+                              .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                                         .sentAt(currentInstant.minus(Duration.ofDays(NINE_DAYS)))
+                                                         .taskId(generateRandomUppercaseUUID())
+                                                         .build())
+                              .ehrReceivedAcknowledgement(EhrExtractStatus.EhrReceivedAcknowledgement.builder().errors(List.of(
+                                  EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails
+                                      .builder()
+                                      .code(ALTERNATIVE_ERROR_CODE)
+                                      .display(ERROR_MESSAGE)
+                                      .build())).build())
+                              .build());
+
+        doReturn(true).when(ehrExtractStatusServiceSpy).isEhrStatusWaitingForFinalAck(conversationId);
+        doReturn(ehrExtractStatusWithEhrReceivedAckWithErrors).when(ehrExtractStatusRepository).findByConversationId(conversationId);
+        when(ack.getErrors()).thenReturn(null);
+        when(ehrExtractStatusServiceSpy.logger()).thenReturn(logger);
+
+        ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
+
+        verify(logger, times(1))
+            .warn("Received an ACK message with a conversation_id=" + conversationId + " that is a duplicate");
+    }
+
+    private String generateRandomUppercaseUUID() {
+        return UUID.randomUUID().toString().toUpperCase();
+    }
+
+    private EhrExtractStatus addInProgressTransfers(String conversationId) {
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackPending(buildPositiveAckPending())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(conversationId)
+            .created(Instant.now().minus(Duration.ofDays(TWENTY_DAYS)))
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                                .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                       .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                       .taskId(generateRandomUppercaseUUID())
+                                       .build())
+            .ehrExtractMessageId(generateRandomUppercaseUUID())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                                   .documents(List.of())
+                                   .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                                     .accessedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                     .objectName(generateRandomUppercaseUUID() + ".json")
+                                     .taskId(generateRandomUppercaseUUID())
+                                     .build())
+            .messageTimestamp(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .updatedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .build();
+
+        ehrExtractStatusRepository.save(extractStatus);
+        return extractStatus;
+    }
+
+    private EhrExtractStatus.AckPending buildPositiveAckPending() {
+        return EhrExtractStatus.AckPending.builder()
+            .messageId(generateRandomUppercaseUUID())
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .updatedAt(FIVE_DAYS_AGO.toString())
+            .build();
+    }
+
+    private EhrExtractStatus.AckToRequester buildPositiveAckToRequester() {
+        return EhrExtractStatus.AckToRequester.builder()
+            .detail(null)
+            .messageId(generateRandomUppercaseUUID())
+            .reasonCode(null)
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .build();
+    }
+
+    private EhrExtractStatus.EhrRequest buildEhrRequest() {
+        return EhrExtractStatus.EhrRequest.builder()
+            .messageId(generateRandomUppercaseUUID())
+            .build();
     }
 
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -409,6 +409,27 @@ class EhrExtractStatusServiceTest {
     }
 
     @Test
+    void shouldNotDoAnythingIfThereAreNoEhrExtractStatusThatExceeded8Days() {
+
+        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
+        var inProgressConversationId = generateRandomUppercaseUUID();
+
+        EhrExtractStatus ehrExtractStatus = addInProgressTransfers(inProgressConversationId);
+        ehrExtractStatus.setEhrExtractCorePending(
+            EhrExtractStatus.EhrExtractCorePending
+                .builder()
+                .sentAt(FIVE_DAYS_AGO)
+                .build());
+
+        doReturn(List.of(ehrExtractStatus)).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
+
+        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
+
+        verify(ehrExtractStatusServiceSpy, never())
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(), ERROR_CODE, ERROR_MESSAGE);
+    }
+
+    @Test
     void updateEhrExtractStatusListWithEhrReceivedAcknowledgementError() {
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
         var inProgressConversationId = generateRandomUppercaseUUID();

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -436,8 +437,6 @@ class EhrExtractStatusServiceTest {
 
         ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
-        verify(ehrExtractStatusServiceSpy, times(1))
-            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
         verify(logger).info("EHR status (EHR received acknowledgement) record successfully "
                                + "updated in the database with error information conversation_id: {}", inProgressConversationId);
     }
@@ -455,7 +454,7 @@ class EhrExtractStatusServiceTest {
                                                                             any(FindAndModifyOptions.class), any());
         when(ehrExtractStatusServiceSpy.logger()).thenReturn(logger);
 
-        ehrExtractStatusServiceSpy.updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus),
+        ehrExtractStatusServiceSpy.updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(Stream.of(ehrExtractStatus),
                                                                                                  ERROR_CODE,
                                                                                                  ERROR_MESSAGE);
 
@@ -490,7 +489,7 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
         verify(ehrExtractStatusServiceSpy, never())
-            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(Stream.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
     }
 
     @Test
@@ -503,7 +502,7 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
         verify(ehrExtractStatusServiceSpy, never())
-            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(), ERROR_CODE, ERROR_MESSAGE);
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(Stream.of(), ERROR_CODE, ERROR_MESSAGE);
     }
 
     @Test
@@ -520,7 +519,7 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
         verify(ehrExtractStatusServiceSpy, never())
-            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(), ERROR_CODE, ERROR_MESSAGE);
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(Stream.of(), ERROR_CODE, ERROR_MESSAGE);
     }
 
     @Test
@@ -541,7 +540,7 @@ class EhrExtractStatusServiceTest {
         ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
 
         verify(ehrExtractStatusServiceSpy, never())
-            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(), ERROR_CODE, ERROR_MESSAGE);
+            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(Stream.of(), ERROR_CODE, ERROR_MESSAGE);
     }
 
     @Test
@@ -556,7 +555,7 @@ class EhrExtractStatusServiceTest {
 
         var exception = assertThrows(EhrExtractException.class,
                                      () -> ehrExtractStatusServiceSpy.updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(
-                                            List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE));
+                                         Stream.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE));
 
         assertEquals("Couldn't update EHR received acknowledgement with error information because EHR status doesn't exist, "
                      + "conversation_id: " + inProgressConversationId,
@@ -578,7 +577,7 @@ class EhrExtractStatusServiceTest {
 
         assertThrows(Exception.class,
                          () -> ehrExtractStatusServiceSpy.updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(
-                             List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE));
+                             Stream.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE));
 
         verify(logger).error(eq("An unexpected error occurred for conversation_id: {}"),
                              eq(inProgressConversationId),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -128,9 +128,9 @@ class EhrExtractStatusServiceTest {
 
         ehrExtractStatusServiceSpy.updateEhrExtractStatusAck(conversationId, ack);
 
-        verify(logger, never()).warn(eq("Received an ACK message with a conversation_id={} exceeded 8 days"), eq(conversationId));
+        verify(logger, never()).warn("Received an ACK message with a conversation_id={} exceeded 8 days", eq(conversationId));
         verify(logger, times(1))
-                            .info(eq("Database successfully updated with EHRAcknowledgement, conversation_id: " + conversationId));
+                            .info("Database successfully updated with EHRAcknowledgement, conversation_id: " + conversationId);
     }
 
     @Test
@@ -368,8 +368,8 @@ class EhrExtractStatusServiceTest {
 
         verify(ehrExtractStatusServiceSpy, times(1))
             .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(ehrExtractStatus), ERROR_CODE, ERROR_MESSAGE);
-        verify(logger).info(eq("EHR status (EHR received acknowledgement) record successfully "
-                               + "updated in the database with error information conversation_id: {}"),
+        verify(logger).info("EHR status (EHR received acknowledgement) record successfully "
+                               + "updated in the database with error information conversation_id: {}",
                              eq(inProgressConversationId));
     }
 
@@ -439,23 +439,6 @@ class EhrExtractStatusServiceTest {
 
     @Test
     void shouldNotUpdateStatusWhenInProgressTransfersWithNullEhrExtractCorePendingExist() {
-
-        EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
-        var inProgressConversationId = generateRandomUppercaseUUID();
-
-        EhrExtractStatus ehrExtractStatus = addInProgressTransfers(inProgressConversationId);
-        ehrExtractStatus.setEhrExtractCorePending(null);
-
-        doReturn(List.of(ehrExtractStatus)).when(ehrExtractStatusServiceSpy).findInProgressTransfers();
-
-        ehrExtractStatusServiceSpy.checkForEhrExtractAckTimeouts();
-
-        verify(ehrExtractStatusServiceSpy, never())
-            .updateEhrExtractStatusListWithEhrReceivedAcknowledgementError(List.of(), ERROR_CODE, ERROR_MESSAGE);
-    }
-
-    @Test
-    void shouldThrowExceptionWhenReturnedEhrExtractStatusIsNull() {
 
         EhrExtractStatusService ehrExtractStatusServiceSpy = spy(ehrExtractStatusService);
         var inProgressConversationId = generateRandomUppercaseUUID();

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
@@ -2,12 +2,22 @@ package uk.nhs.adaptors.gp2gp.ehr.status.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.ERROR;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.ORIGINAL_FILE;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.PLACEHOLDER;
 import static uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus.SKELETON_MESSAGE;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.COMPLETE;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.COMPLETE_WITH_ISSUES;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_INCUMBENT;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.FAILED_NME;
+import static uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus.IN_PROGRESS;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,10 +27,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusRepository;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
+import uk.nhs.adaptors.gp2gp.ehr.status.model.EhrStatus;
 import uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus;
+import uk.nhs.adaptors.gp2gp.ehr.status.model.MigrationStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class EhrStatusBaseServiceTest {
+
+    public static final int TWENTY_DAYS = 20;
+    public static final String ACK_TYPE = "AA";
+    private static final String NACK_TYPE = "AE";
+    private static final Instant NOW = Instant.now();
+    private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
+    public static final int NINE_DAYS = 9;
+    public static final String DISPLAY_ERROR_MESSAGE = "The acknowledgement has been received after 8 days";
+    public static final String ERROR_CODE = "99";
 
     private static final EhrExtractStatus.GpcDocument SKELETON_DOCUMENT = EhrExtractStatus.GpcDocument.builder()
         .isSkeleton(true)
@@ -94,6 +115,163 @@ public class EhrStatusBaseServiceTest {
         FileStatus fileStatus = ehrStatusBaseService.getFileStatus(ORIGINAL_FILE_DOCUMENT, ONE_FAILED_ACK_LIST);
 
         assertThat(fileStatus).isEqualTo(ERROR);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToFailedIncumbent() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = inProgressTransfers(conversationId);
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
+
+        assertEquals(FAILED_INCUMBENT, migrationStatus);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToInProgress() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = inProgressTransfers(conversationId);
+        ehrExtractStatus.setEhrReceivedAcknowledgement(null);
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
+
+        assertEquals(IN_PROGRESS, migrationStatus);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToComplete() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = completeTransfers(conversationId);
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
+
+        assertEquals(COMPLETE, migrationStatus);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToCompleteWithIssues() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = completeTransfers(conversationId);
+
+        List<EhrStatus.AttachmentStatus> attachmentStatusList = new ArrayList<>();
+        attachmentStatusList.add(
+            EhrStatus.AttachmentStatus.builder().fileStatus(PLACEHOLDER).build());
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, attachmentStatusList);
+
+        assertEquals(COMPLETE_WITH_ISSUES, migrationStatus);
+    }
+
+    @Test
+    void evaluateMigrationStatusResolvesToFailedNme() {
+        var conversationId = generateRandomUppercaseUUID();
+        EhrExtractStatus ehrExtractStatus = inProgressTransfers(conversationId);
+        ehrExtractStatus.getAckPending().setTypeCode(NACK_TYPE);
+        ehrExtractStatus.setError(EhrExtractStatus.Error.builder().build());
+
+        MigrationStatus migrationStatus = ehrStatusBaseService.evaluateMigrationStatus(ehrExtractStatus, List.of());
+
+        assertEquals(FAILED_NME, migrationStatus);
+    }
+
+    private String generateRandomUppercaseUUID() {
+        return UUID.randomUUID().toString().toUpperCase();
+    }
+
+    private EhrExtractStatus inProgressTransfers(String conversationId) {
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackPending(buildPositiveAckPending())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(conversationId)
+            .created(Instant.now().minus(Duration.ofDays(TWENTY_DAYS)))
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                                .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                       .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                       .taskId(generateRandomUppercaseUUID())
+                                       .build())
+            .ehrExtractMessageId(generateRandomUppercaseUUID())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                                   .documents(List.of())
+                                   .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                                     .accessedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                     .objectName(generateRandomUppercaseUUID() + ".json")
+                                     .taskId(generateRandomUppercaseUUID())
+                                     .build())
+            .messageTimestamp(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .updatedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .ehrReceivedAcknowledgement(
+                EhrExtractStatus.EhrReceivedAcknowledgement.builder().errors(List.of(
+                    EhrExtractStatus.EhrReceivedAcknowledgement.ErrorDetails
+                        .builder()
+                        .code(ERROR_CODE)
+                        .display(DISPLAY_ERROR_MESSAGE)
+                        .build())).build())
+            .build();
+
+        return extractStatus;
+    }
+
+    private EhrExtractStatus completeTransfers(String conversationId) {
+        EhrExtractStatus extractStatus = EhrExtractStatus.builder()
+            .ackPending(buildPositiveAckPending())
+            .ackToRequester(buildPositiveAckToRequester())
+            .conversationId(conversationId)
+            .created(Instant.now().minus(Duration.ofDays(TWENTY_DAYS)))
+            .ehrExtractCore(EhrExtractStatus.EhrExtractCore.builder()
+                                .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                .build())
+            .ehrExtractCorePending(EhrExtractStatus.EhrExtractCorePending.builder()
+                                       .sentAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                       .taskId(generateRandomUppercaseUUID())
+                                       .build())
+            .ehrExtractMessageId(generateRandomUppercaseUUID())
+            .ehrRequest(buildEhrRequest())
+            .gpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder()
+                                   .documents(List.of())
+                                   .build())
+            .gpcAccessStructured(EhrExtractStatus.GpcAccessStructured.builder()
+                                     .accessedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+                                     .objectName(generateRandomUppercaseUUID() + ".json")
+                                     .taskId(generateRandomUppercaseUUID())
+                                     .build())
+            .messageTimestamp(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .updatedAt(Instant.now().minus(Duration.ofDays(NINE_DAYS)))
+            .ehrReceivedAcknowledgement(
+                EhrExtractStatus.EhrReceivedAcknowledgement.builder()
+                    .conversationClosed(FIVE_DAYS_AGO)
+                    .build())
+            .build();
+
+        return extractStatus;
+    }
+
+    private EhrExtractStatus.AckPending buildPositiveAckPending() {
+        return EhrExtractStatus.AckPending.builder()
+            .messageId(generateRandomUppercaseUUID())
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .updatedAt(FIVE_DAYS_AGO.toString())
+            .build();
+    }
+
+    private EhrExtractStatus.AckToRequester buildPositiveAckToRequester() {
+        return EhrExtractStatus.AckToRequester.builder()
+            .detail(null)
+            .messageId(generateRandomUppercaseUUID())
+            .reasonCode(null)
+            .taskId(generateRandomUppercaseUUID())
+            .typeCode(ACK_TYPE)
+            .build();
+    }
+
+    private EhrExtractStatus.EhrRequest buildEhrRequest() {
+        return EhrExtractStatus.EhrRequest.builder()
+            .messageId(generateRandomUppercaseUUID())
+            .build();
     }
 
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/status/service/EhrStatusBaseServiceTest.java
@@ -22,10 +22,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import uk.nhs.adaptors.gp2gp.ehr.EhrExtractStatusRepository;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 import uk.nhs.adaptors.gp2gp.ehr.status.model.EhrStatus;
 import uk.nhs.adaptors.gp2gp.ehr.status.model.FileStatus;
@@ -76,8 +74,6 @@ public class EhrStatusBaseServiceTest {
             .build()
     );
 
-    @Mock
-    private EhrExtractStatusRepository extractStatusRepository;
     @InjectMocks
     private EhrStatusBaseService ehrStatusBaseService;
 


### PR DESCRIPTION
## What
Scheduler delay checker was added.

## Why

The scheduler delay checker now marks transfer requests as failed if they exceed the 8-day limit without receiving a final acknowledgment.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
