### PR TITLE
NIAD-3173 - Add GitHub Action to replace current GP2GP Jenkins build

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 jobs:
-
-# ------------------------------------------------------------
-
   checkstyle:
     name: Checkstyle
     runs-on: ubuntu-latest
@@ -22,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'corretto'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -52,7 +49,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'corretto'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -71,8 +68,6 @@ jobs:
           path: "./service/build/reports/**"
           compression-level: 9
 
-# ------------------------------------------------------------
-
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -85,7 +80,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'corretto'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -116,7 +111,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'corretto'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -210,7 +205,7 @@ jobs:
       - name: Get End-to-End Test Reports
         run: |
           mkdir e2e-test-reports
-          docker cp e2e-tests:/home/gradle/e2e-tests/build/reports/** ./e2e-test-reports
+          docker cp e2e-tests:/home/gradle/e2e-tests/build/reports ./e2e-test-reports
 
       - name: Dump Docker Logs
         if: always()
@@ -236,9 +231,7 @@ jobs:
           docker network rm commonforgp2gp
         working-directory: ./docker
 
-# ------------------------------------------------------------
-
-  docker:
+  build-and-publish-docker-images:
     name: Build & Publish Docker Images
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests, end-to-end-tests]

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+
 jobs:
   checkstyle:
     name: Checkstyle
@@ -323,7 +324,8 @@ jobs:
       - name: Build Docker Image
         run: |
           # Create Docker Tag
-          DOCKER_TAG="${{ secrets.DOCKER_REGISTRY }}/${{ matrix.config.repository }}:$BUILD_ID"
+          DOCKER_REGISTRY="https://${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
+          DOCKER_TAG="$DOCKER_REGISTRY/${{ matrix.config.repository }}:$BUILD_ID"
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
 
           # Build Image
@@ -331,7 +333,8 @@ jobs:
 
       - name: Login to AWS ECR
         run: |
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin https://${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+          DOCKER_REGISTRY="https://${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
+          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin $DOCKER_REGISTRY
 
       - name: Publish image to ECR
         run: docker push $DOCKER_TAG

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -158,7 +158,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: 'Integration Test Reports - Docker Logs'
+          name: 'Integration Test Reports & Docker Logs'
           path: |
             ./service/build/reports/**
             ./scripts/logs/**
@@ -207,8 +207,9 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
         working-directory: ./docker
 
-      - name: Copy End-to-End Tests Report
-        run: docker cp e2e-tests:/home/gradle/e2e-tests/build .
+      - name: Get End-to-End Test Reports
+        run: docker cp e2e-tests:/home/gradle/e2e-tests/build/reports/** .
+        working-directory: ./service/build/reports
 
       - name: Dump Docker Logs
         if: always()
@@ -221,7 +222,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: 'End-to-End Test Results - Docker Logs'
+          name: 'End-to-End Test Results & Docker Logs'
           path: |
             ./service/build/reports/**
             ./scripts/logs/**

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -103,7 +103,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Execute Unit Tests
-        run: ./gradlew test --daemon --parallel --build-cache
+        run: ./gradlew test --parallel --build-cache
         working-directory: ./service
 
       - name: Collect Artifacts
@@ -162,7 +162,7 @@ jobs:
         working-directory: ./docker
 
       - name: Execute Integration Tests
-        run: ./gradlew integrationTest --daemon
+        run: ./gradlew integrationTest
         working-directory: ./service
 
       - name: Dump Docker Logs

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Create Temporary Artifacts Directory
-        run: mkdir artifacts
-
       - name: Checkstyle
         run: |
           ./gradlew checkStyleMain --parallel
@@ -35,7 +32,9 @@ jobs:
         working-directory: ./service
 
       - name: Collect Artifacts
-        run: cp -r ./service/build/reports ./artifacts
+        run: |
+          mkdir -p artifacts
+          cp -r ./service/build/reports ./artifacts
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -64,9 +63,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Create Temporary Artifacts Directory
-        run: mkdir artifacts
-
       - name: Spotbugs
         run: |
           ./gradlew spotbugsMain --parallel
@@ -74,7 +70,9 @@ jobs:
         working-directory: ./service
 
       - name: Collect Artifacts
-        run: cp -r ./service/build/reports ./artifacts
+        run: |
+          mkdir -p artifacts
+          cp -r ./service/build/reports ./artifacts
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -104,15 +102,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Create Temporary Artifacts Directory
-        run: mkdir artifacts
-
       - name: Execute Unit Tests
         run: ./gradlew test --parallel --build-cache
         working-directory: ./service
 
       - name: Collect Artifacts
-        run: cp -r ./service/build/reports ./artifacts
+        run: |
+          mkdir -p artifacts
+          cp -r ./service/build/reports ./artifacts
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -141,9 +138,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      - name: Create Temporary Artifacts Directory
-        run: mkdir artifacts
 
       - name: Start Docker Dependencies
         env:
@@ -180,6 +174,7 @@ jobs:
 
       - name: Collect Artifacts
         run: |
+          mkdir -p artifacts
           cp -r ./service/build/reports ./artifacts
           cp -r ./scripts/logs ./artifacts
 
@@ -209,9 +204,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-
-      - name: Create Temporary Artifacts Directory
-        run: mkdir artifacts
 
       - name: Run E2E Tests
         env:
@@ -249,6 +241,7 @@ jobs:
 
       - name: Collect Artifacts
         run: |
+          mkdir -p artifacts
           docker cp e2e-tests:/home/gradle/e2e-tests/build/reports ./artifacts
           cp -r ./scripts/logs ./artifacts
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -171,6 +171,7 @@ jobs:
           chmod +x dump_docker_logs.sh
           ./dump_docker_logs.sh
         working-directory: ./scripts
+        shell: bash
 
       - name: Collect Artifacts
         run: |
@@ -237,6 +238,7 @@ jobs:
           chmod +x dump_docker_logs.sh
           ./dump_docker_logs.sh
         working-directory: ./scripts
+        shell: bash
 
       - name: Collect Artifacts
         run: |
@@ -332,6 +334,7 @@ jobs:
         run: docker push $DOCKER_TAG
 
       - name: Logout of AWS ECR (Clean up Credentials)
+        if: always()
         run: |
           DOCKER_REGISTRY="https://${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
           docker logout $DOCKER_REGISTRY

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -1,0 +1,305 @@
+name: GP2GP Build Workflow
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+
+# ------------------------------------------------------------
+
+  checkstyle:
+    name: Checkstyle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21 LTS
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'corretto'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Checkstyle
+        run: |
+          ./gradlew checkStyleMain
+          ./gradlew checkstyleTest
+        working-directory: ./service
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: 'Checkstyle Reports'
+          path: "./service/build/reports/**"
+          compression-level: 9
+
+  spotbugs:
+    name: Spotbugs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21 LTS
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'corretto'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Spotbugs
+        run: |
+          ./gradlew spotbugsMain
+          ./gradlew spotbugsTest
+        working-directory: ./service
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: 'Spotbugs Reports'
+          path: "./service/build/reports/**"
+          compression-level: 9
+
+# ------------------------------------------------------------
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: [checkstyle, spotbugs]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21 LTS
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'corretto'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Unit Tests
+        run: ./gradlew test
+        working-directory: ./service
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: 'Unit Test Reports'
+          path: |
+            ./service/build/reports/**
+            ./scripts/logs/**
+          compression-level: 9
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: [checkstyle, spotbugs]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21 LTS
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'corretto'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Start Docker Dependencies
+        env:
+          GPC_SUPPLIER_ODS_CODE: "XYZ222"
+          GP2GP_SERVER_PORT: "8080"
+          GP2GP_AMQP_BROKERS: "amqp://activemq:5672"
+          GP2GP_MONGO_URI: "mongodb://mongodb:27017"
+          GP2GP_MONGO_DATABASE_NAME: "gp2gp"
+          GP2GP_MHS_OUTBOUND_URL: "http://mock-mhs-adaptor:8081/mock-mhs-endpoint/accept-only"
+          GP2GP_GPC_GET_URL: "http://gpcc:8090/@ODS_CODE@/STU3/1/gpconnect"
+          GP2GP_LARGE_ATTACHMENT_THRESHOLD: "4500000"
+          GP2GP_LARGE_EHR_EXTRACT_THRESHOLD: "4500000"
+          GPC_CONSUMER_SERVER_PORT: "8090"
+          GPC_CONSUMER_SDS_URL: "http://wiremock:8080/spine-directory/"
+          GPC_CONSUMER_SDS_APIKEY: "anykey"
+          GP2GP_LOGGING_LEVEL: DEBUG
+          GPC_CONSUMER_LOGGING_LEVEL: DEBUG
+        run: |
+          docker network create commonforgp2gp
+          docker compose build
+          docker compose up mock-mhs-adaptor mongodb activemq wiremock gpcc gp2gp --detach
+        working-directory: ./docker
+
+      - name: Execute Integration Tests
+        run: ./gradlew integrationTest
+        working-directory: ./service
+
+      - name: Dump Docker Logs
+        if: always()
+        run: |
+          chmod +x dump_docker_logs.sh
+          ./dump_docker_logs.sh
+        working-directory: ./scripts
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: 'Integration Test Reports - Docker Logs'
+          path: |
+            ./service/build/reports/**
+            ./scripts/logs/**
+          compression-level: 9
+
+      - name: Stop Docker Dependencies
+        if: always()
+        run: |
+          docker compose down --rmi=local --remove-orphans &&
+          docker compose rm &&
+          docker network rm commonforgp2gp
+        working-directory: ./docker
+
+  end-to-end-tests:
+    name: End-to-End Testing
+    runs-on: ubuntu-latest
+    needs: [checkstyle, spotbugs]
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run E2E Tests
+        env:
+          GP2GP_SERVER_PORT: "8080"
+          GP2GP_BASE_URL: "http://gp2gp:$GP2GP_SERVER_PORT"
+          GP2GP_AMQP_BROKERS: "amqp://activemq:5672"
+          GP2GP_MONGO_URI: "mongodb://mongodb:27017"
+          GP2GP_MONGO_DATABASE_NAME: "gp2gp"
+          GP2GP_MHS_MOCK_BASE_URL: "http://mock-mhs-adaptor:8081"
+          GP2GP_MHS_OUTBOUND_URL: "$GP2GP_MHS_MOCK_BASE_URL/mock-mhs-endpoint"
+          GP2GP_GPC_GET_URL: "http://gpcc:8090/@ODS_CODE@/STU3/1/gpconnect"
+          GP2GP_LARGE_ATTACHMENT_THRESHOLD: "31216"
+          GP2GP_LARGE_EHR_EXTRACT_THRESHOLD: "31216"
+          GP2GP_GPC_CLIENT_MAX_BACKOFF_ATTEMPTS: 0
+          GP2GP_MHS_CLIENT_MAX_BACKOFF_ATTEMPTS: 0
+          GPC_CONSUMER_SERVER_PORT: "8090"
+          GPC_CONSUMER_SDS_URL: "http://wiremock:8080/spine-directory/"
+          GPC_CONSUMER_SDS_APIKEY: "anykey"
+          GPC_CONSUMER_LOGGING_LEVEL: "DEBUG"
+          GPC_SUPPLIER_ODS_CODE: "XYZ222"
+          GP2GP_LOGGING_LEVEL: "DEBUG"
+          MHS_MOCK_REQUEST_JOURNAL_ENABLED: "true"
+        run: |
+          docker network create commonforgp2gp
+          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml build gp2gp-e2e-tests
+          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
+        working-directory: ./docker
+
+      - name: Copy End-to-End Tests Report
+        run: docker cp e2e-tests:/home/gradle/e2e-tests/build .
+
+      - name: Dump Docker Logs
+        if: always()
+        run: |
+          chmod +x dump_docker_logs.sh
+          ./dump_docker_logs.sh
+        working-directory: ./scripts
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: 'End-to-End Test Results - Docker Logs'
+          path: |
+            ./service/build/reports/**
+            ./scripts/logs/**
+          compression-level: 9
+
+      - name: Stop Docker Dependencies
+        if: always()
+        run: |
+          docker compose -f docker/docker-compose.yml -f docker/docker-compose-e2e-tests.yml down
+          docker network rm commonforgp2gp
+        working-directory: ./docker
+
+# ------------------------------------------------------------
+
+  docker:
+    name: Build & Publish Docker Images
+    runs-on: ubuntu-latest
+    needs: [unit-tests, integration-tests, end-to-end-tests]
+    permissions:
+        id-token: write
+        contents: read
+    strategy:
+      matrix:
+        config:
+          - directory: service
+            repository: gp2gp
+            build-context: .
+          - directory: wiremock
+            repository: gp2gp-wiremock
+            build-context: .
+          - directory: mock-mhs-adaptor
+            repository: gp2gp-mock-mhs
+            build-context: .
+          - directory: gpcc-mock
+            repository: gp2gp-gpcc-mock
+            build-context: ./docker/gpcc-mock
+          - directory: gpc-api-mock
+            repository: gp2gp-gpc-api-mock
+            build-context: ./docker/gpc-api-mock
+          - directory: sds-api-mock
+            repository: gp2gp-sds-api-mock
+            build-context: ./docker/sds-api-mock
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: gp2gp_pull_request
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Generate Build ID
+        run: |
+          BUILD_ID=$(python3 ./scripts/tag.py ${{ github.head_ref || github.ref_name }} ${{ github.run_number }} ${{ github.sha }})
+          echo "Generated the build tag: $BUILD_ID"
+          echo "BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+
+      - name: Build Docker Image
+        run: |
+          # Create Docker Tag
+          DOCKER_TAG="${{ secrets.DOCKER_REGISTRY }}/${{ matrix.config.repository }}:$BUILD_ID"
+          echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
+
+          # Build Image
+          docker build -f ./docker/${{ matrix.config.directory }}/Dockerfile -t $DOCKER_TAG ${{ matrix.config.build-context }}
+
+      - name: Login to AWS ECR
+        run: |
+          USER_IDENTITY=$(aws sts get-caller-identity --query 'Account' --output text) &&
+          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin https://$USER_IDENTITY.dkr.ecr.$AWS_REGION.amazonaws.com
+
+      - name: Publish image to ECR
+        run: docker push $DOCKER_TAG

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -24,19 +24,28 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Create Temporary Artifacts Directory
+        run: mkdir artifacts
+
       - name: Checkstyle
         run: |
           ./gradlew checkStyleMain
           ./gradlew checkstyleTest
         working-directory: ./service
 
+      - name: Collect Artifacts
+        run: cp -r ./service/build/reports ./artifacts
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: 'Checkstyle Reports'
-          path: "./service/build/reports/**"
+          path: ./artifacts/**
           compression-level: 9
+
+      - name: Delete Temporary Artifacts
+        run: rm -r ./artifacts
 
   spotbugs:
     name: Spotbugs
@@ -54,19 +63,28 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Create Temporary Artifacts Directory
+        run: mkdir artifacts
+
       - name: Spotbugs
         run: |
           ./gradlew spotbugsMain
           ./gradlew spotbugsTest
         working-directory: ./service
 
+      - name: Collect Artifacts
+        run: cp -r ./service/build/reports ./artifacts
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: 'Spotbugs Reports'
-          path: "./service/build/reports/**"
+          path: ./artifacts/**
           compression-level: 9
+
+      - name: Delete Temporary Artifacts
+        run: rm -r ./artifacts
 
   unit-tests:
     name: Unit Tests
@@ -85,19 +103,26 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Create Temporary Artifacts Directory
+        run: mkdir artifacts
+
       - name: Execute Unit Tests
         run: ./gradlew test
         working-directory: ./service
+
+      - name: Collect Artifacts
+        run: cp -r ./service/build/reports ./artifacts
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: 'Unit Test Reports'
-          path: |
-            ./service/build/reports/**
-            ./scripts/logs/**
+          path: ./artifacts/**
           compression-level: 9
+
+      - name: Delete Temporary Artifacts
+        run: rm -r ./artifacts
 
   integration-tests:
     name: Integration Tests
@@ -115,6 +140,9 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      - name: Create Temporary Artifacts Directory
+        run: mkdir artifacts
 
       - name: Start Docker Dependencies
         env:
@@ -149,14 +177,17 @@ jobs:
           ./dump_docker_logs.sh
         working-directory: ./scripts
 
+      - name: Collect Artifacts
+        run: |
+          cp -r ./service/build/reports ./artifacts
+          cp -r ./scripts/logs ./artifacts
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: 'Integration Test Reports & Docker Logs'
-          path: |
-            ./service/build/reports/**
-            ./scripts/logs/**
+          path: ./artifacts/**
           compression-level: 9
 
       - name: Stop Docker Dependencies
@@ -167,6 +198,9 @@ jobs:
           docker network rm commonforgp2gp
         working-directory: ./docker
 
+      - name: Delete Temporary Artifacts
+        run: rm -r ./artifacts
+
   end-to-end-tests:
     name: End-to-End Testing
     runs-on: ubuntu-latest
@@ -174,6 +208,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Create Temporary Artifacts Directory
+        run: mkdir artifacts
 
       - name: Run E2E Tests
         env:
@@ -202,11 +239,6 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from gp2gp-e2e-tests mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
         working-directory: ./docker
 
-      - name: Get End-to-End Test Reports
-        run: |
-          mkdir e2e-test-reports
-          docker cp e2e-tests:/home/gradle/e2e-tests/build/reports ./e2e-test-reports
-
       - name: Dump Docker Logs
         if: always()
         run: |
@@ -214,14 +246,17 @@ jobs:
           ./dump_docker_logs.sh
         working-directory: ./scripts
 
+      - name: Collect Artifacts
+        run: |
+          docker cp e2e-tests:/home/gradle/e2e-tests/build/reports ./artifacts
+          cp -r ./service/build/reports ./artifacts
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: 'End-to-End Test Results & Docker Logs'
-          path: |
-            ./e2e-test-reports/**
-            ./scripts/logs/**
+          path: ./artifacts/**
           compression-level: 9
 
       - name: Stop Docker Dependencies
@@ -230,6 +265,9 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml down
           docker network rm commonforgp2gp
         working-directory: ./docker
+
+      - name: Delete Temporary Artifacts
+        run: rm -r ./artifacts
 
   build-and-publish-docker-images:
     name: Build & Publish Docker Images

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -103,7 +103,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Execute Unit Tests
-        run: ./gradlew test --parallel --build-cache
+        run: ./gradlew test --daemon --parallel --build-cache
         working-directory: ./service
 
       - name: Collect Artifacts
@@ -162,7 +162,7 @@ jobs:
         working-directory: ./docker
 
       - name: Execute Integration Tests
-        run: ./gradlew integrationTest
+        run: ./gradlew integrationTest --daemon
         working-directory: ./service
 
       - name: Dump Docker Logs

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -189,8 +189,8 @@ jobs:
       - name: Stop Docker Dependencies
         if: always()
         run: |
-          docker compose down --rmi=local --remove-orphans &&
-          docker compose rm &&
+          docker compose down --rmi=local --remove-orphans
+          docker compose rm
           docker network rm commonforgp2gp
         working-directory: ./docker
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Run E2E Tests
         env:
           GP2GP_SERVER_PORT: "8080"
-          GP2GP_BASE_URL: "http://gp2gp:$GP2GP_SERVER_PORT"
+          GP2GP_BASE_URL: "http://gp2gp:8080"
           GP2GP_AMQP_BROKERS: "amqp://activemq:5672"
           GP2GP_MONGO_URI: "mongodb://mongodb:27017"
           GP2GP_MONGO_DATABASE_NAME: "gp2gp"
@@ -203,8 +203,8 @@ jobs:
           MHS_MOCK_REQUEST_JOURNAL_ENABLED: "true"
         run: |
           docker network create commonforgp2gp
-          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml build gp2gp-e2e-tests
-          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
+          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml build
+          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from gp2gp-e2e-tests mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
         working-directory: ./docker
 
 #      - name: Get End-to-End Test Reports

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -330,3 +330,8 @@ jobs:
 
       - name: Publish image to ECR
         run: docker push $DOCKER_TAG
+
+      - name: Logout of AWS ECR (Clean up Credentials)
+        run: |
+          DOCKER_REGISTRY="https://${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
+          docker logout $DOCKER_REGISTRY

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -228,8 +228,7 @@ jobs:
           MHS_MOCK_REQUEST_JOURNAL_ENABLED: "true"
         run: |
           docker network create commonforgp2gp
-          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml build
-          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from gp2gp-e2e-tests mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
+          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --build --exit-code-from gp2gp-e2e-tests mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
         working-directory: ./docker
 
       - name: Dump Docker Logs

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -188,7 +188,7 @@ jobs:
           GP2GP_MONGO_URI: "mongodb://mongodb:27017"
           GP2GP_MONGO_DATABASE_NAME: "gp2gp"
           GP2GP_MHS_MOCK_BASE_URL: "http://mock-mhs-adaptor:8081"
-          GP2GP_MHS_OUTBOUND_URL: "$GP2GP_MHS_MOCK_BASE_URL/mock-mhs-endpoint"
+          GP2GP_MHS_OUTBOUND_URL: "http://mock-mhs-adaptor:8081/mock-mhs-endpoint"
           GP2GP_GPC_GET_URL: "http://gpcc:8090/@ODS_CODE@/STU3/1/gpconnect"
           GP2GP_LARGE_ATTACHMENT_THRESHOLD: "31216"
           GP2GP_LARGE_EHR_EXTRACT_THRESHOLD: "31216"

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -45,7 +45,7 @@ jobs:
           path: ./artifacts/**
           compression-level: 9
 
-      - name: Delete Temporary Artifacts
+      - name: Temporary Artifacts Cleanup
         run: rm -rf ./artifacts
 
   spotbugs:
@@ -84,7 +84,7 @@ jobs:
           path: ./artifacts/**
           compression-level: 9
 
-      - name: Delete Temporary Artifacts
+      - name: Temporary Artifacts Cleanup
         run: rm -rf ./artifacts
 
   unit-tests:
@@ -122,7 +122,7 @@ jobs:
           path: ./artifacts/**
           compression-level: 9
 
-      - name: Delete Temporary Artifacts
+      - name: Temporary Artifacts Cleanup
         run: rm -rf ./artifacts
 
   integration-tests:
@@ -199,7 +199,7 @@ jobs:
           docker network rm commonforgp2gp
         working-directory: ./docker
 
-      - name: Delete Temporary Artifacts
+      - name: Temporary Artifacts Cleanup
         run: rm -rf ./artifacts
 
   end-to-end-tests:
@@ -267,7 +267,7 @@ jobs:
           docker network rm commonforgp2gp
         working-directory: ./docker
 
-      - name: Delete Temporary Artifacts
+      - name: Temporary Artifacts Cleanup
         run: rm -rf ./artifacts
 
   build-and-publish-docker-images:

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -207,9 +207,10 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from gp2gp-e2e-tests mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
         working-directory: ./docker
 
-#      - name: Get End-to-End Test Reports
-#        run: docker cp e2e-tests:/home/gradle/e2e-tests/build/reports/** .
-#        working-directory: ./service/build/reports
+      - name: Get End-to-End Test Reports
+        run: |
+          mkdir e2e-test-reports
+          docker cp e2e-tests:/home/gradle/e2e-tests/build/reports/** ./e2e-test-reports
 
       - name: Dump Docker Logs
         if: always()
@@ -224,7 +225,7 @@ jobs:
         with:
           name: 'End-to-End Test Results & Docker Logs'
           path: |
-            ./service/build/reports/**
+            ./e2e-test-reports/**
             ./scripts/logs/**
           compression-level: 9
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -207,9 +207,9 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml up --exit-code-from mongodb activemq gp2gp wiremock gpcc gp2gp-e2e-tests
         working-directory: ./docker
 
-      - name: Get End-to-End Test Reports
-        run: docker cp e2e-tests:/home/gradle/e2e-tests/build/reports/** .
-        working-directory: ./service/build/reports
+#      - name: Get End-to-End Test Reports
+#        run: docker cp e2e-tests:/home/gradle/e2e-tests/build/reports/** .
+#        working-directory: ./service/build/reports
 
       - name: Dump Docker Logs
         if: always()

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Checkstyle
         run: |
-          ./gradlew checkStyleMain
-          ./gradlew checkstyleTest
+          ./gradlew checkStyleMain --parallel
+          ./gradlew checkstyleTest --parallel
         working-directory: ./service
 
       - name: Collect Artifacts
@@ -46,7 +46,7 @@ jobs:
           compression-level: 9
 
       - name: Delete Temporary Artifacts
-        run: rm -r ./artifacts
+        run: rm -rf ./artifacts
 
   spotbugs:
     name: Spotbugs
@@ -69,8 +69,8 @@ jobs:
 
       - name: Spotbugs
         run: |
-          ./gradlew spotbugsMain
-          ./gradlew spotbugsTest
+          ./gradlew spotbugsMain --parallel
+          ./gradlew spotbugsTest --parallel
         working-directory: ./service
 
       - name: Collect Artifacts
@@ -85,7 +85,7 @@ jobs:
           compression-level: 9
 
       - name: Delete Temporary Artifacts
-        run: rm -r ./artifacts
+        run: rm -rf ./artifacts
 
   unit-tests:
     name: Unit Tests
@@ -108,7 +108,7 @@ jobs:
         run: mkdir artifacts
 
       - name: Execute Unit Tests
-        run: ./gradlew test
+        run: ./gradlew test --parallel --build-cache
         working-directory: ./service
 
       - name: Collect Artifacts
@@ -123,7 +123,7 @@ jobs:
           compression-level: 9
 
       - name: Delete Temporary Artifacts
-        run: rm -r ./artifacts
+        run: rm -rf ./artifacts
 
   integration-tests:
     name: Integration Tests
@@ -200,7 +200,7 @@ jobs:
         working-directory: ./docker
 
       - name: Delete Temporary Artifacts
-        run: rm -r ./artifacts
+        run: rm -rf ./artifacts
 
   end-to-end-tests:
     name: End-to-End Testing
@@ -268,7 +268,7 @@ jobs:
         working-directory: ./docker
 
       - name: Delete Temporary Artifacts
-        run: rm -r ./artifacts
+        run: rm -rf ./artifacts
 
   build-and-publish-docker-images:
     name: Build & Publish Docker Images

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Build Docker Image
         run: |
           # Create Docker Tag
-          DOCKER_REGISTRY="https://${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
+          DOCKER_REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
           DOCKER_TAG="$DOCKER_REGISTRY/${{ matrix.config.repository }}:$BUILD_ID"
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -249,7 +249,7 @@ jobs:
       - name: Collect Artifacts
         run: |
           docker cp e2e-tests:/home/gradle/e2e-tests/build/reports ./artifacts
-          cp -r ./service/build/reports ./artifacts
+          cp -r ./scripts/logs ./artifacts
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Stop Docker Dependencies
         if: always()
         run: |
-          docker compose -f docker/docker-compose.yml -f docker/docker-compose-e2e-tests.yml down
+          docker compose -f docker-compose.yml -f docker-compose-e2e-tests.yml down
           docker network rm commonforgp2gp
         working-directory: ./docker
 

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -305,8 +305,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: gp2gp_pull_request
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: gp2gp_github_action_build_workflow
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Setup Python 3.12
@@ -331,8 +331,7 @@ jobs:
 
       - name: Login to AWS ECR
         run: |
-          USER_IDENTITY=$(aws sts get-caller-identity --query 'Account' --output text) &&
-          aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin https://$USER_IDENTITY.dkr.ecr.$AWS_REGION.amazonaws.com
+          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin https://${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
 
       - name: Publish image to ECR
         run: docker push $DOCKER_TAG

--- a/scripts/dump_docker_logs.sh
+++ b/scripts/dump_docker_logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir -p ./logs
+
+container_names=$(docker ps --format '{{.Names}}')
+
+for container in $container_names; do
+    docker logs "$container" > ./logs/"$container".log
+    echo "Logs saved for container: $container"
+done

--- a/scripts/dump_docker_logs.sh
+++ b/scripts/dump_docker_logs.sh
@@ -2,7 +2,7 @@
 
 mkdir -p ./logs
 
-container_names=$(docker ps --format '{{.Names}}')
+container_names=$(docker ps -a --format '{{.Names}}')
 
 for container in $container_names; do
     docker logs "$container" > ./logs/"$container".log


### PR DESCRIPTION
Due to ongoing challenges with Jenkins, we have initiated the migration to GitHub Actions as part of our strategy to enhance our CI/CD pipeline. This pull request introduces the initial GitHub Actions workflow, `build_workflow.yml`. This workflow is designed to replicate the stages defined in the existing `Jenkinsfile`, ensuring continuity and consistency in our build process.