### PR TITLE
NIAD-3173 - Update `create_build_id.sh` to fix incorrect Build ID generation

### DIFF
--- a/scripts/create_build_id.sh
+++ b/scripts/create_build_id.sh
@@ -8,9 +8,9 @@ clean_tag_element() {
 generate_tag() {
     local clean_branch_name=$(clean_tag_element "$1")
     local clean_build_id=$(clean_tag_element "$2")
-    local short_git_hash=$(${!3}:0:7)
+    local git_hash="$3"
 
-    local tag="${clean_branch_name}-${clean_build_id}-${short_git_hash}"
+    local tag="${clean_branch_name}-${clean_build_id}-${git_hash:0:7}"
 
     echo "$tag"
 }


### PR DESCRIPTION
This PR resolves an issue where the build ID was not being generated correctly. The fix ensures the build process now reliably produces the appropriate build ID.