### PR TITLE
NIAD-3137: Add test for unsupported resource when mapping `Encounter`

### DIFF
--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -5,6 +5,7 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Encounter;
 import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.QuestionnaireResponse;
 import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.jetbrains.annotations.NotNull;
@@ -29,9 +30,11 @@ import uk.nhs.adaptors.gp2gp.ehr.mapper.diagnosticreport.SpecimenMapper;
 import uk.nhs.adaptors.gp2gp.ehr.utils.BloodPressureValidator;
 import uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils;
 import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
+import uk.nhs.adaptors.gp2gp.utils.IdUtil;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -422,6 +425,21 @@ public class EncounterComponentsMapperTest {
 
         assertThat(mappedXml)
             .isEqualToIgnoringWhitespace(expectedXml);
+    }
+
+    @Test
+    void When_MapResourceToComponent_With_UnsupportedResource_Expect_PlaceholderCommentProduced() {
+        var resource = new QuestionnaireResponse()
+            .setIdElement(
+                IdUtil.buildIdType(ResourceType.QuestionnaireResponse, "questionnaire-response-id")
+            );
+
+        var expectedComponent = "<!-- QuestionnaireResponse/questionnaire-response-id -->";
+
+        var actualComponent = encounterComponentsMapper.mapResourceToComponent(resource);
+
+        assertThat(actualComponent)
+            .isEqualTo(Optional.of(expectedComponent));
     }
 
     private static Stream<Arguments> containedResourceMappingArguments() {


### PR DESCRIPTION
## What

Add test for unsupported resource when mapping `Encounter`

## Why

This functionality was present but not tested.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
