### PR TITLE
NIAD-3137: Refactor to use IsEqualToIgnoringWhitespace

### DIFF
--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -227,7 +227,8 @@ public class EncounterComponentsMapperTest {
 
         System.out.println(mappedXml);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test
@@ -238,7 +239,8 @@ public class EncounterComponentsMapperTest {
         var encounter = extractEncounter(bundle);
 
         String mappedXml = encounterComponentsMapper.mapComponents(encounter);
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @ParameterizedTest
@@ -307,7 +309,8 @@ public class EncounterComponentsMapperTest {
 
         String mappedXml = encounterComponentsMapper.mapComponents(encounter);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test
@@ -321,7 +324,8 @@ public class EncounterComponentsMapperTest {
 
         String mappedXml = encounterComponentsMapper.mapComponents(encounter);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test
@@ -332,7 +336,8 @@ public class EncounterComponentsMapperTest {
 
         String mappedXml = encounterComponentsMapper.mapComponents(encounter);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test
@@ -346,7 +351,8 @@ public class EncounterComponentsMapperTest {
 
         String mappedXml = encounterComponentsMapper.mapComponents(encounter);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test
@@ -361,7 +367,8 @@ public class EncounterComponentsMapperTest {
 
         String mappedXml = encounterComponentsMapper.mapComponents(encounter);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test
@@ -372,7 +379,8 @@ public class EncounterComponentsMapperTest {
 
         String mappedXml = encounterComponentsMapper.mapComponents(encounter);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @ParameterizedTest
@@ -386,7 +394,8 @@ public class EncounterComponentsMapperTest {
 
         System.out.println(mappedXml);
 
-        assertThat(removeLineEndingsAndWhiteSpace(mappedXml)).isEqualTo(removeLineEndingsAndWhiteSpace(expectedXml));
+        assertThat(mappedXml)
+            .isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test
@@ -469,17 +478,6 @@ public class EncounterComponentsMapperTest {
             Arguments.of("input-two-resources-category.json", "output-two-resources-category.xml"),
             Arguments.of("input-referenced-observation.json", "output-referenced-observation.xml")
         );
-    }
-
-    private String removeLineEndingsAndWhiteSpace(String input) {
-        return input
-            .replace("\n", " ")
-            .replace("\r", " ")
-            .replaceAll("\\s+", " ")
-            .replaceAll("\"\\s>", "\">")
-            .replaceAll("\"\\s/>", "\"/>")
-            .replaceAll("\\s+<", "<");
-
     }
 
     private Encounter extractEncounter(Bundle bundle) {


### PR DESCRIPTION
## What

A quick refactor to use IsEqualToIgnoringWhitespace rather than helper method doing the same thing.

## Why

Code clarity and to remove unnecessary helper function

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes