### PR TITLE
README.md, fix broken link to API catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GP2GP Sending Adaptor [![GP2GP Build Workflow](https://github.com/NHSDigital/integration-adaptor-gp2gp/actions/workflows/build_workflow.yml/badge.svg)](https://github.com/NHSDigital/integration-adaptor-gp2gp/actions/workflows/build_workflow.yml)
 
-National Integration Adaptor - [GP2GP Sending Adaptor](https://digital.nhs.uk/developer/api-catalogue/gp2gp/gp2gp---integration-adaptor)
+National Integration Adaptor - [GP2GP Sending Adaptor](https://digital.nhs.uk/developer/api-catalogue/gp2gp/gp2gp-sending-adaptor)
 
 The existing GP2GP solution uses a legacy messaging standard and infrastructure (HL7v3 and Spine TMS). Reliance 
 on these standards going forward presents a significant barrier to successful GP2GP implementation by new suppliers, 


### PR DESCRIPTION
## Why

Looks like the URL was changed at some point, which is fair given the previous URL appeared malformed.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
