### PR TITLE
General refactors to `AbsentAttachmentFileMapper.java` and `GetAbsentAttachmentTaskExecutor.java`

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AbsentAttachmentFileMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AbsentAttachmentFileMapper.java
@@ -1,27 +1,20 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import com.github.mustachejava.Mustache;
-
-import lombok.RequiredArgsConstructor;
-import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.AbsentAttachmentParameters;
 import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
+import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.AbsentAttachmentParameters;
+
+import static uk.nhs.adaptors.gp2gp.ehr.mapper.Template.ABSENT_ATTACHMENT;
 
 @Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class AbsentAttachmentFileMapper {
-
-    private static final Mustache ABSENT_ATTACHMENT_TEMPLATE = TemplateUtils.loadTemplate("absent_attachment_template.mustache");
-
-    public static String mapDataToAbsentAttachment(String originalFilename, String odsCode, String conversationId) {
-        var absentAttachment = AbsentAttachmentParameters.builder()
+public final class AbsentAttachmentFileMapper {
+    public String mapFileDataToAbsentAttachment(String originalFilename, String odsCode, String conversationId) {
+        final AbsentAttachmentParameters absentAttachment = AbsentAttachmentParameters.builder()
             .originalFilename(originalFilename)
             .odsCode(odsCode)
             .conversationId(conversationId)
             .build();
-        return TemplateUtils.fillTemplate(ABSENT_ATTACHMENT_TEMPLATE, absentAttachment);
-    }
 
+        return TemplateUtils.fillTemplate(ABSENT_ATTACHMENT.mustacheTemplate, absentAttachment);
+    }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AbsentAttachmentFileMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AbsentAttachmentFileMapper.java
@@ -15,6 +15,6 @@ public final class AbsentAttachmentFileMapper {
             .conversationId(conversationId)
             .build();
 
-        return TemplateUtils.fillTemplate(ABSENT_ATTACHMENT.mustacheTemplate, absentAttachment);
+        return TemplateUtils.fillTemplate(ABSENT_ATTACHMENT.getMustacheTemplate(), absentAttachment);
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/Template.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/Template.java
@@ -1,12 +1,14 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
 import com.github.mustachejava.Mustache;
+import lombok.Getter;
 import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
 
+@Getter
 public enum Template {
     ABSENT_ATTACHMENT("absent_attachment_template.mustache");
 
-    public final Mustache mustacheTemplate;
+    private final Mustache mustacheTemplate;
 
     Template(String mustacheTemplate) {
         this.mustacheTemplate = TemplateUtils.loadTemplate(mustacheTemplate);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/Template.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/Template.java
@@ -1,0 +1,14 @@
+package uk.nhs.adaptors.gp2gp.ehr.mapper;
+
+import com.github.mustachejava.Mustache;
+import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
+
+public enum Template {
+    ABSENT_ATTACHMENT("absent_attachment_template.mustache");
+
+    public final Mustache mustacheTemplate;
+
+    Template(String mustacheTemplate) {
+        this.mustacheTemplate = TemplateUtils.loadTemplate(mustacheTemplate);
+    }
+}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutorTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutorTest.java
@@ -7,22 +7,31 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.adaptors.gp2gp.common.storage.StorageConnectorService;
+import uk.nhs.adaptors.gp2gp.ehr.mapper.AbsentAttachmentFileMapper;
 import uk.nhs.adaptors.gp2gp.gpc.DetectTranslationCompleteService;
 import uk.nhs.adaptors.gp2gp.gpc.DocumentToMHSTranslator;
 
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class GetAbsentAttachmentTaskExecutorTest {
-    @Mock private EhrExtractStatusService ehrExtractStatusService;
-    @Mock private DocumentToMHSTranslator documentToMHSTranslator;
-    @Mock private DetectTranslationCompleteService detectTranslationCompleteService;
-    @Mock private StorageConnectorService storageConnectorService;
+    @Mock
+    private EhrExtractStatusService ehrExtractStatusService;
+
+    @Mock
+    private DocumentToMHSTranslator documentToMHSTranslator;
+
+    @Mock
+    private DetectTranslationCompleteService detectTranslationCompleteService;
+
+    @Mock
+    private StorageConnectorService storageConnectorService;
+
+    @Mock
+    private AbsentAttachmentFileMapper absentAttachmentFileMapper;
 
     @InjectMocks
     private GetAbsentAttachmentTaskExecutor getAbsentAttachmentTaskExecutor;
@@ -30,10 +39,10 @@ public class GetAbsentAttachmentTaskExecutorTest {
     @Test
     public void When_HandleAbsentAttachmentWithNoError_Expect_DefaultValueIsUsedAsError() {
         var taskDefinition = buildAbsentAttachment(null);
+        when(absentAttachmentFileMapper.mapFileDataToAbsentAttachment(anyString(), anyString(), anyString()))
+            .thenReturn("file content");
 
-        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
-            taskDefinition,
-            Optional.empty());
+        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition,Optional.empty());
 
         verify(ehrExtractStatusService).updateEhrExtractStatusAccessDocument(
             any(),
@@ -47,6 +56,8 @@ public class GetAbsentAttachmentTaskExecutorTest {
     @Test
     public void When_HandleAbsentAttachmentWithJustTaskDefinitionTitle_Expect_TitleIsUsedAsError() {
         var taskDefinition = buildAbsentAttachment("This-is-the-task-definition-title");
+        when(absentAttachmentFileMapper.mapFileDataToAbsentAttachment(anyString(), anyString(), anyString()))
+            .thenReturn("file content");
 
         getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
             taskDefinition,
@@ -64,6 +75,8 @@ public class GetAbsentAttachmentTaskExecutorTest {
     @Test
     public void When_HandleAbsentAttachmentWithJustGpcResponseError_Expect_GpcResponseErrorIsUsedAsError() {
         var taskDefinition = buildAbsentAttachment(null);
+        when(absentAttachmentFileMapper.mapFileDataToAbsentAttachment(anyString(), anyString(), anyString()))
+            .thenReturn("file content");
 
         getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
             taskDefinition,
@@ -81,6 +94,8 @@ public class GetAbsentAttachmentTaskExecutorTest {
     @Test
     public void When_HandleAbsentAttachmentWithGpcResponseErrorAndTitle_Expect_GpcResponseErrorIsUsedAsError() {
         var taskDefinition = buildAbsentAttachment("This-is-the-task-definition-title");
+        when(absentAttachmentFileMapper.mapFileDataToAbsentAttachment(anyString(), anyString(), anyString()))
+            .thenReturn("file content");
 
         getAbsentAttachmentTaskExecutor.handleAbsentAttachment(
             taskDefinition,
@@ -98,6 +113,8 @@ public class GetAbsentAttachmentTaskExecutorTest {
     @Test
     public void When_HandleAbsentAttachment_Expect_AbsentAttachmentFilenameIsUsed() {
         var taskDefinition = buildAbsentAttachment(null);
+        when(absentAttachmentFileMapper.mapFileDataToAbsentAttachment(anyString(), anyString(), anyString()))
+            .thenReturn("file content");
 
         getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition, Optional.empty());
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutorTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/GetAbsentAttachmentTaskExecutorTest.java
@@ -1,11 +1,14 @@
 package uk.nhs.adaptors.gp2gp.ehr;
 
 import org.jetbrains.annotations.Nullable;
-import org.junit.jupiter.api.Test;
+
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+
 import uk.nhs.adaptors.gp2gp.common.storage.StorageConnectorService;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.AbsentAttachmentFileMapper;
 import uk.nhs.adaptors.gp2gp.gpc.DetectTranslationCompleteService;
@@ -14,7 +17,11 @@ import uk.nhs.adaptors.gp2gp.gpc.DocumentToMHSTranslator;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.eq;
 
 @ExtendWith(MockitoExtension.class)
 public class GetAbsentAttachmentTaskExecutorTest {
@@ -42,7 +49,7 @@ public class GetAbsentAttachmentTaskExecutorTest {
         when(absentAttachmentFileMapper.mapFileDataToAbsentAttachment(anyString(), anyString(), anyString()))
             .thenReturn("file content");
 
-        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition,Optional.empty());
+        getAbsentAttachmentTaskExecutor.handleAbsentAttachment(taskDefinition, Optional.empty());
 
         verify(ehrExtractStatusService).updateEhrExtractStatusAccessDocument(
             any(),


### PR DESCRIPTION
The first micro-PR to refactor the `AbsentAttachmentFileMapper.java` and `GetAbsentAttachmentTaskExecutor.java`.