### PR TITLE
Reduce the risk of NMEs reading our internal guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ GP2GP 2.2b producer, or those wishing to decommission their existing producer, m
 ## Table of contents
 
 1. [Guidance for operating the adaptor as a New Market Entrant](OPERATING.md)
-2. [Guidance on integrating with the adaptors APIs](#how-to-query-the-ehr-status-api)
-3. [Guidance for developing the adaptor](developer-information.md)
-4. [Documentation on how this adaptor maps GPConnect concepts to GP2GP concepts](https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation)
+1. [Guidance on integrating with the adaptors APIs](#how-to-query-the-ehr-status-api)
+1. [Documentation on how this adaptor maps GPConnect concepts to GP2GP concepts](https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation)
 
 ## How to query the EHR Status API
 
@@ -297,6 +296,11 @@ The response will contain a JSON array of the following:
 ### Sequence Diagram
 
 ![Sequence diagram](documentation/sequence/sequence.svg)
+
+## NIA Support (NHS England) guidance
+
+If you are are New Market Entrant, please read the guidance linked from the [table of contents](#table-of-contents).
+If you are looking to make changes to the adaptor you should first read the [guidance for developing the adaptor](developer-information.md).
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ The response will contain a JSON array of the following:
 ## NIA Support (NHS England) guidance
 
 If you are are New Market Entrant, please read the guidance linked from the [table of contents](#table-of-contents).
-If you are looking to make changes to the adaptor you should first read the [guidance for developing the adaptor](developer-information.md).
+If you are looking to make changes to the adaptor you should first read the [guidance for developing the adaptor](nhs-england-developer-information.md).
 
 ## Disclaimer
 

--- a/nhs-england-developer-information.md
+++ b/nhs-england-developer-information.md
@@ -1,5 +1,8 @@
 # Developer Information
 
+> [!WARNING]
+> The audience of this documentation is designed for NHS England developers.
+
 ## Requirements:
 
 * JDK 21 - We develop the adaptor in Java with Spring Boot


### PR DESCRIPTION
## Why

While it's important to keep our internal docs open source. They appear to be causing confusion to NMEs who are accidentally reading them.

Move the link to the developer-information.md to the bottom of the README.md

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
