### PR TITLE
NIAD-3144-FIXES - Add `confidentialityCode` support for `Observation (Filing Comments)`

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -214,9 +214,15 @@ public class DiagnosticReportMapper {
             .filter(observation -> observation.hasEffectiveDateTimeType() || observation.hasEffectivePeriod())
             .filter(this::hasCommentNote)
             .findFirst()
-            .map(this::extractDateFromObservation)
-            .map(dateString -> buildNarrativeStatementForDiagnosticReport(
-                diagnosticReportIssued, CommentType.AGGREGATE_COMMENT_SET.getCode(), dateString, null))
+            .map(observation -> {
+                final String date = extractDateFromObservation(observation);
+                return buildNarrativeStatementForDiagnosticReport(
+                    diagnosticReportIssued,
+                    CommentType.AGGREGATE_COMMENT_SET.getCode(),
+                    date,
+                    confidentialityService.generateConfidentialityCode(observation).orElse(null)
+                );
+            })
             .ifPresent(reportLevelNarrativeStatements::append);
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -214,15 +214,12 @@ public class DiagnosticReportMapper {
             .filter(observation -> observation.hasEffectiveDateTimeType() || observation.hasEffectivePeriod())
             .filter(this::hasCommentNote)
             .findFirst()
-            .map(observation -> {
-                final String date = extractDateFromObservation(observation);
-                return buildNarrativeStatementForDiagnosticReport(
-                    diagnosticReportIssued,
-                    CommentType.AGGREGATE_COMMENT_SET.getCode(),
-                    date,
-                    confidentialityService.generateConfidentialityCode(observation).orElse(null)
-                );
-            })
+            .map(observation -> buildNarrativeStatementForDiagnosticReport(
+                diagnosticReportIssued,
+                CommentType.AGGREGATE_COMMENT_SET.getCode(),
+                extractDateFromObservation(observation),
+                confidentialityService.generateConfidentialityCode(observation).orElse(null)
+            ))
             .ifPresent(reportLevelNarrativeStatements::append);
     }
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -227,10 +227,10 @@ class DiagnosticReportMapperTest {
 
     @Test
     void When_DiagnosticReport_With_ObservationEffectivePeriodAndCommentNote_Expect_NarrativeStatementConfidentialityCodePresent() {
-        final String diagnosticReportFileName = "diagnostic-report-with-effective-datetime-filing-comment.json";
+        final String diagnosticReportFileName = "diagnostic-report-with-effective-period-filing-comment.json";
         final DiagnosticReport diagnosticReport = getDiagnosticReportResourceFromJson(diagnosticReportFileName);
         final Bundle bundle = getBundleResourceFromJson(INPUT_JSON_BUNDLE_WITH_FILING_COMMENTS);
-        final Observation observation = (Observation) bundle.getEntry().get(2).getResource();
+        final Observation observation = (Observation) bundle.getEntry().get(3).getResource();
         final InputBundle inputBundle = new InputBundle(bundle);
         final List<String> expectedXPaths = Collections.singletonList(
             "/component/CompoundStatement/component[1]/NarrativeStatement/" + getNopatConfidentialityCodeXpathSegment()

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -176,8 +176,7 @@ class DiagnosticReportMapperTest {
         final String testFile = "diagnostic-report-with-multi-specimens-noscrub.json";
         final DiagnosticReport diagnosticReport = getDiagnosticReportResourceFromJson(testFile);
 
-        when(confidentialityService.generateConfidentialityCode(diagnosticReport))
-            .thenReturn(Optional.empty());
+        when(confidentialityService.generateConfidentialityCode(diagnosticReport)).thenReturn(Optional.empty());
 
         final String result = mapper.mapDiagnosticReportToCompoundStatement(diagnosticReport);
 
@@ -196,8 +195,7 @@ class DiagnosticReportMapperTest {
 
         when(confidentialityService.generateConfidentialityCode(bundle.getEntry().getFirst().getResource()))
             .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
-        when(messageContext.getInputBundleHolder())
-            .thenReturn(inputBundle);
+        when(messageContext.getInputBundleHolder()).thenReturn(inputBundle);
 
         diagnosticReport.setStatus(null);
 
@@ -217,10 +215,8 @@ class DiagnosticReportMapperTest {
             "/component/CompoundStatement/component[1]/NarrativeStatement/" + getNopatConfidentialityCodeXpathSegment()
         );
 
-        when(confidentialityService.generateConfidentialityCode(observation))
-            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
-        when(messageContext.getInputBundleHolder())
-            .thenReturn(inputBundle);
+        when(confidentialityService.generateConfidentialityCode(observation)).thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
+        when(messageContext.getInputBundleHolder()).thenReturn(inputBundle);
 
         diagnosticReport.setStatus(null);
 
@@ -240,10 +236,8 @@ class DiagnosticReportMapperTest {
             "/component/CompoundStatement/component[1]/NarrativeStatement/" + getNopatConfidentialityCodeXpathSegment()
         );
 
-        when(confidentialityService.generateConfidentialityCode(observation))
-            .thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
-        when(messageContext.getInputBundleHolder())
-            .thenReturn(inputBundle);
+        when(confidentialityService.generateConfidentialityCode(observation)).thenReturn(Optional.of(NOPAT_HL7_CONFIDENTIALITY_CODE));
+        when(messageContext.getInputBundleHolder()).thenReturn(inputBundle);
 
         diagnosticReport.setStatus(null);
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -209,7 +209,8 @@ class DiagnosticReportMapperTest {
         final String diagnosticReportFileName = "diagnostic-report-with-effective-datetime-filing-comment.json";
         final DiagnosticReport diagnosticReport = getDiagnosticReportResourceFromJson(diagnosticReportFileName);
         final Bundle bundle = getBundleResourceFromJson(INPUT_JSON_BUNDLE_WITH_FILING_COMMENTS);
-        final Observation observation = (Observation) bundle.getEntry().get(2).getResource();
+        final int observationBundleEntryIndex = 2;
+        final Observation observation = (Observation) bundle.getEntry().get(observationBundleEntryIndex).getResource();
         final InputBundle inputBundle = new InputBundle(bundle);
         final List<String> expectedXPaths = Collections.singletonList(
             "/component/CompoundStatement/component[1]/NarrativeStatement/" + getNopatConfidentialityCodeXpathSegment()
@@ -230,7 +231,8 @@ class DiagnosticReportMapperTest {
         final String diagnosticReportFileName = "diagnostic-report-with-effective-period-filing-comment.json";
         final DiagnosticReport diagnosticReport = getDiagnosticReportResourceFromJson(diagnosticReportFileName);
         final Bundle bundle = getBundleResourceFromJson(INPUT_JSON_BUNDLE_WITH_FILING_COMMENTS);
-        final Observation observation = (Observation) bundle.getEntry().get(3).getResource();
+        final int observationBundleEntryIndex = 3;
+        final Observation observation = (Observation) bundle.getEntry().get(observationBundleEntryIndex).getResource();
         final InputBundle inputBundle = new InputBundle(bundle);
         final List<String> expectedXPaths = Collections.singletonList(
             "/component/CompoundStatement/component[1]/NarrativeStatement/" + getNopatConfidentialityCodeXpathSegment()

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/XmlAssertion.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/XmlAssertion.java
@@ -5,6 +5,8 @@ import org.assertj.core.api.AbstractAssert;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+
 public class XmlAssertion extends AbstractAssert<XmlAssertion, String> {
 
     protected XmlAssertion(String xml) {
@@ -39,6 +41,14 @@ public class XmlAssertion extends AbstractAssert<XmlAssertion, String> {
                 actual
             );
         }
+    }
+
+    /**
+     * Verifies that the actual {@link String} XML contains all the given xPath values.
+     * @param xPaths A Collection of Strings (xPaths) expected to be within the provided XML.
+     */
+    public void containsAllXPaths(Collection<String> xPaths) {
+        xPaths.forEach(this::containsXPath);
     }
 
     /**

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-effective-datetime-filing-comment.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-effective-datetime-filing-comment.json
@@ -1,0 +1,43 @@
+{
+    "resourceType":"DiagnosticReport",
+    "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098",
+    "meta":{
+      "profile":[
+        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+      ]
+    },
+    "identifier":[
+      {
+        "system":"https://EMISWeb/A82038",
+        "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098"
+      }
+    ],
+    "status":"unknown",
+    "category":{
+      "coding":[
+        {
+          "system":"http://hl7.org/fhir/v2/0074",
+          "code":"PAT",
+          "display":"Pathology (gross & histopath, not surgical)"
+        }
+      ]
+    },
+    "code":{
+      "coding":[
+        {
+          "system":"http://snomed.info/sct",
+          "code":"721981007",
+          "display":"Diagnostic studies report"
+        }
+      ]
+    },
+    "subject":{
+      "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+    },
+    "issued":"2010-02-25T15:41:00+00:00",
+    "result":[
+      {
+        "reference":"Observation/AAD8F388-F020-4945-B775-89BC8D2EA354"
+      }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-effective-period-filing-comment.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-effective-period-filing-comment.json
@@ -1,0 +1,43 @@
+{
+  "resourceType":"DiagnosticReport",
+  "id":"96B93E28-293D-46E7-B4C2-D477EEBF7098",
+  "meta":{
+    "profile":[
+      "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+    ]
+  },
+  "identifier":[
+    {
+      "system":"https://EMISWeb/A82038",
+      "value":"96B93E28-293D-46E7-B4C2-D477EEBF7098"
+    }
+  ],
+  "status":"unknown",
+  "category":{
+    "coding":[
+      {
+        "system":"http://hl7.org/fhir/v2/0074",
+        "code":"PAT",
+        "display":"Pathology (gross & histopath, not surgical)"
+      }
+    ]
+  },
+  "code":{
+    "coding":[
+      {
+        "system":"http://snomed.info/sct",
+        "code":"721981007",
+        "display":"Diagnostic studies report"
+      }
+    ]
+  },
+  "subject":{
+    "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+  },
+  "issued":"2010-02-25T15:41:00+00:00",
+  "result":[
+    {
+      "reference":"Observation/85C08A50-236F-4177-A0F8-006A6BE7163C"
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/fhir_bundle_with_filing_comments.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/fhir_bundle_with_filing_comments.json
@@ -152,6 +152,7 @@
             "reference": "Practitioner/C8FD0E2C-3124-4C72-AC8D-ABEA65537D1B"
           }
         ],
+        "comment": "(q) - Normal - No Action",
         "related": [
           {
             "type": "derived-from",
@@ -207,6 +208,7 @@
             "reference": "Practitioner/C8FD0E2C-3124-4C72-AC8D-ABEA65537D1B"
           }
         ],
+        "comment": "(q) - Normal - No Action",
         "related": [
           {
             "type": "derived-from",

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/fhir_bundle_with_filing_comments.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/fhir_bundle_with_filing_comments.json
@@ -109,6 +109,113 @@
           }
         ]
       }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "AAD8F388-F020-4945-B775-89BC8D2EA354",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+          ],
+          "security": [
+            {
+              "system": "http://hl7.org/fhir/v3/ActCode",
+              "code": "NOPAT",
+              "display": "no disclosure to patient, family or caregivers without attending provider's authorization"
+            }
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://EMISWeb/A82038",
+            "value": "AAD8F388-F020-4945-B775-89BC8D2EA354-COMM"
+          }
+        ],
+        "status": "unknown",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "37331000000100",
+              "display": "Comment note"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+        },
+        "effectiveDateTime": "2010-02-23",
+        "issued": "2020-12-15T15:17:04.917+00:00",
+        "performer": [
+          {
+            "reference": "Practitioner/C8FD0E2C-3124-4C72-AC8D-ABEA65537D1B"
+          }
+        ],
+        "related": [
+          {
+            "type": "derived-from",
+            "target": {
+              "reference": "Observation/AAD8F388-F020-4945-B775-89BC8D2EA354"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "85C08A50-236F-4177-A0F8-006A6BE7163C",
+        "meta": {
+          "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+          ],
+          "security": [
+            {
+              "system": "http://hl7.org/fhir/v3/ActCode",
+              "code": "NOPAT",
+              "display": "no disclosure to patient, family or caregivers without attending provider's authorization"
+            }
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://EMISWeb/A82038",
+            "value": "85C08A50-236F-4177-A0F8-006A6BE7163C-COMM"
+          }
+        ],
+        "status": "unknown",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "37331000000100",
+              "display": "Comment note"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+        },
+        "effectivePeriod": {
+          "start": "2021-01-01T10:30:00+00:00",
+          "end": "2021-02-01T10:30:00+00:00"
+        },
+        "issued": "2020-12-15T15:17:04.917+00:00",
+        "performer": [
+          {
+            "reference": "Practitioner/C8FD0E2C-3124-4C72-AC8D-ABEA65537D1B"
+          }
+        ],
+        "related": [
+          {
+            "type": "derived-from",
+            "target": {
+              "reference": "Observation/85C08A50-236F-4177-A0F8-006A6BE7163C"
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## What

This pull request introduces support for `confidentialityCode` within the `buildNarrativeStatementForObservationTimes` method in `DiagnosticReportMapper.java`.

## Why

More details can be found on the [ticket](https://nhse-dsic.atlassian.net/browse/NIAD-3144).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users