### PR TITLE
NIAD-2840: introducing a variable that can be changed via config file

### DIFF
--- a/service/src/intTest/resources/application.yml
+++ b/service/src/intTest/resources/application.yml
@@ -14,6 +14,7 @@ management:
         include: info, health, metrics
 
 gp2gp:
+  ehr-extract-sent-days-limit: ${EHR_EXTRACT_SENT_DAYS_LIMIT:8}
   redactions-enabled: ${GP2GP_REDACTIONS_ENABLED:false}
   largeAttachmentThreshold: ${GP2GP_LARGE_ATTACHMENT_THRESHOLD:4500000} # value in bytes. Default value for Spine is ~4.5MB
   largeEhrExtractThreshold: ${GP2GP_LARGE_ATTACHMENT_THRESHOLD:4500000}

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -148,7 +148,7 @@ public class EhrExtractStatusService {
         return ehrReceivedAckErrorDetailsThatContainsSearchedErrCodeAndMsg.isPresent();
     }
 
-    public boolean hasLastUpdateExceededEightDays(EhrExtractStatus ehrExtractStatus, Instant time) {
+    public boolean hasLastUpdateExceededAckTimeoutLimit(EhrExtractStatus ehrExtractStatus, Instant time) {
 
         if (ehrExtractStatus.getEhrExtractCorePending() == null) {
             return false;
@@ -366,7 +366,7 @@ public class EhrExtractStatusService {
             return;
         }
 
-        if (hasAcknowledgementExceededEightDays(conversationId, ack.getReceived())
+        if (hasAcknowledgementExceededAckTimeoutLimit(conversationId, ack.getReceived())
             && hasEhrStatusReceivedAckWithUnexpectedConditionErrors(conversationId)) {
 
             logger().warn("Received an ACK message with conversation_id: {}, "
@@ -620,10 +620,10 @@ public class EhrExtractStatusService {
         return ehrExtractStatus.getEhrReceivedAcknowledgement() != null;
     }
 
-    private boolean hasAcknowledgementExceededEightDays(String conversationId, Instant ackReceivedTimestamp) {
+    private boolean hasAcknowledgementExceededAckTimeoutLimit(String conversationId, Instant ackReceivedTimestamp) {
         var ehrExtractStatus = fetchEhrExtractStatus(conversationId, "ACK");
 
-        return hasLastUpdateExceededEightDays(ehrExtractStatus, ackReceivedTimestamp);
+        return hasLastUpdateExceededAckTimeoutLimit(ehrExtractStatus, ackReceivedTimestamp);
     }
 
     private boolean checkForContinueOutOfOrderAndDuplicate(String conversationId) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusService.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -118,7 +119,9 @@ public class EhrExtractStatusService {
     private static final String CONTENT_TYPE_PLACEHOLDER = "CONTENT_TYPE_PLACEHOLDER_ID=";
     private static final String FILENAME_TYPE_PLACEHOLDER = "FILENAME_PLACEHOLDER_ID=";
     private static final String ACKS_SET = ACK_HISTORY + DOT + ACKS;
-    public static final int EHR_EXTRACT_SENT_DAYS_LIMIT = 8;
+
+    @Value("${gp2gp.ehr-extract-sent-days-limit}")
+    private int ehrExtractSentDaysLimit;
     private static final String UNEXPECTED_CONDITION_ERROR_CODE = "99";
     public static final String UNEXPECTED_CONDITION_ERROR_MESSAGE = "No acknowledgement has been received within 8 days";
 
@@ -213,7 +216,7 @@ public class EhrExtractStatusService {
 
         long daysSinceLastUpdate = Duration.between(ehrExtractStatus.getEhrExtractCorePending().getSentAt(), time).toDays();
 
-        return daysSinceLastUpdate > EHR_EXTRACT_SENT_DAYS_LIMIT;
+        return daysSinceLastUpdate > ehrExtractSentDaysLimit;
     }
 
     public void saveEhrExtractMessageId(String conversationId, String messageId) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/scheduling/EhrExtractTimeoutScheduler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/scheduling/EhrExtractTimeoutScheduler.java
@@ -36,7 +36,7 @@ public class EhrExtractTimeoutScheduler {
         var ehrExtractStatusWithExceededUpdateLimit = inProgressEhrExtractTransfers
             .stream()
             .filter(ehrExtractStatus -> Objects.isNull(ehrExtractStatus.getEhrReceivedAcknowledgement())
-                                        && ehrExtractStatusService.hasLastUpdateExceededEightDays(ehrExtractStatus, now));
+                                        && ehrExtractStatusService.hasLastUpdateExceededAckTimeoutLimit(ehrExtractStatus, now));
 
         ehrExtractStatusWithExceededUpdateLimit.forEach(ehrExtractStatus -> {
             try {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -10,6 +10,7 @@ management:
         include: info, health, metrics, mappings
 
 gp2gp:
+  ehr-extract-sent-days-limit: ${EHR_EXTRACT_SENT_DAYS_LIMIT:8}
   redactions-enabled: ${GP2GP_REDACTIONS_ENABLED:false}
   largeAttachmentThreshold: ${GP2GP_LARGE_ATTACHMENT_THRESHOLD:4500000} # value in bytes. Default value for Spine is ~4.5MB
   largeEhrExtractThreshold: ${GP2GP_LARGE_EHR_EXTRACT_THRESHOLD:4500000}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrExtractStatusServiceTest.java
@@ -18,6 +18,8 @@ import uk.nhs.adaptors.gp2gp.common.service.TimestampService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrExtractException;
 import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 import uk.nhs.adaptors.gp2gp.mhs.exception.UnrecognisedInteractionIdException;
+
+import java.lang.reflect.Field;
 import java.time.Duration;
 
 import java.time.Instant;
@@ -53,6 +55,7 @@ class EhrExtractStatusServiceTest {
     private static final Instant FIVE_DAYS_AGO = NOW.minus(Duration.ofDays(5));
     public static final String ACK_TYPE = "AA";
     public static final int TWENTY_DAYS = 20;
+    public static final int EHR_EXTRACT_SENT_DAYS_LIMIT = 8;
 
     private ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
     private ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
@@ -77,8 +80,12 @@ class EhrExtractStatusServiceTest {
     private EhrExtractStatusService ehrExtractStatusService;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws NoSuchFieldException, IllegalAccessException {
         ehrExtractStatusService = new EhrExtractStatusService(mongoTemplate, ehrExtractStatusRepository, timestampService);
+
+        Field field = EhrExtractStatusService.class.getDeclaredField("ehrExtractSentDaysLimit");
+        field.setAccessible(true);
+        field.set(ehrExtractStatusService, EHR_EXTRACT_SENT_DAYS_LIMIT);
     }
 
     @Test


### PR DESCRIPTION
## What

ehrExtractSentDaysLimit variable can be changed via application.yml file.

## Why

Customers can adjust the timeout duration by setting a value for EHR_EXTRACT_SENT_DAYS_LIMIT, which will then update the ehrExtractSentDaysLimit accordingly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
