### PR TITLE
NIAD-3151: Adding NOPAT SecurityLabels and Meta Security to ReferredToExternalDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * When mapping consultations which are "flat" (i.e., they contain a `TOPIC` without a `CATEGORY`) we now wrap the 
   resource into a virtual `CATEGORY`.
-* Added a scheduled delay checker to update EhrExtract to "Integration Failure" state if sentAt exceeds 8 days and no acknowledgment is received. 
+* Added a scheduled delay checker to update EhrExtract to "Integration Failure" state if sentAt exceeds 8 days and no acknowledgment is received.
+* When mapping a `DocumentReference` which contains a `NOPAT` `meta.security` or `NOPAT` `securityLabel` tag the resultant XML for that resource
+  will contain a `NOPAT` `confidentialityCode` element.
 
 ### Added
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityService.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.gp2gp.common.service;
 
 import lombok.RequiredArgsConstructor;
 import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.DocumentReference;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -24,9 +25,10 @@ public class ConfidentialityService {
     private final RedactionsContext redactionsContext;
 
     public Optional<String> generateConfidentialityCode(Resource resource) {
-        return redactionsContext.isRedactionMessage() && hasNOPATMetaSecurity(resource)
-            ? Optional.of(REDACTION_CONFIDENTIALITY_CODE)
-            : Optional.empty();
+        return redactionsContext.isRedactionMessage()
+               && (hasNOPATMetaSecurity(resource) || getNOPATSecurityLabels(resource))
+               ? Optional.of(REDACTION_CONFIDENTIALITY_CODE)
+               : Optional.empty();
     }
 
     private boolean isNOPATCoding(Coding coding) {
@@ -37,5 +39,13 @@ public class ConfidentialityService {
         return resource.getMeta().getSecurity()
             .stream()
             .anyMatch(this::isNOPATCoding);
+    }
+
+    public boolean getNOPATSecurityLabels(Resource resource) {
+        return (resource instanceof DocumentReference documentReference)
+               && documentReference
+                   .getSecurityLabel()
+                   .stream()
+                   .anyMatch(codeableConcept -> codeableConcept.getCoding().stream().anyMatch(this::isNOPATCoding));
     }
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityService.java
@@ -26,7 +26,7 @@ public class ConfidentialityService {
 
     public Optional<String> generateConfidentialityCode(Resource resource) {
         return redactionsContext.isRedactionMessage()
-               && (hasNOPATMetaSecurity(resource) || getNOPATSecurityLabels(resource))
+               && (hasNOPATMetaSecurity(resource) || hasNOPATSecurityLabel(resource))
                ? Optional.of(REDACTION_CONFIDENTIALITY_CODE)
                : Optional.empty();
     }
@@ -41,7 +41,7 @@ public class ConfidentialityService {
             .anyMatch(this::isNOPATCoding);
     }
 
-    public boolean getNOPATSecurityLabels(Resource resource) {
+    public boolean hasNOPATSecurityLabel(Resource resource) {
         return (resource instanceof DocumentReference documentReference)
                && documentReference
                    .getSecurityLabel()

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
@@ -137,7 +137,7 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
     }
 
     @Test
-    void When_DocumentReferenceSecurityLabelPopulatedWithNoPat_Expect_NarrativeStatementPopulatesReferredToExternalDocument() {
+    void When_DocReferenceSecurityLabelPopulatedWithNoPat_Expect_NarrativeStatementPopulatesReferredToExternalDocument() {
 
         final String jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY_LABEL);
         final DocumentReference parsedDocumentReference = new FhirParseService().parseResource(jsonInput, DocumentReference.class);
@@ -149,7 +149,7 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
     }
 
     @Test
-    void When_DocRefSecurityLabelPopulatedWithNoPatAndNotReduction_Expect_NarrativeStatementReferredToExternalDocIsNotPopulated() {
+    void When_DocReferenceSecurityLabelPopulatedWithNoPatAndNotReduction_Expect_NarrativeStatementReferredToExternalDocIsNotPopulated() {
 
         final String jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY_LABEL);
         final DocumentReference parsedDocumentReference = new FhirParseService().parseResource(jsonInput, DocumentReference.class);
@@ -161,7 +161,7 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
     }
 
     @Test
-     void When_DocumentReferenceJsonPopulatedWithNoPat_Expect_NarrativeStatementPopulatesReferredToExternalDocument() {
+     void When_DocReferenceJsonPopulatedWithNoPat_Expect_NarrativeStatementPopulatesReferredToExternalDocument() {
 
         final String jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY);
         final DocumentReference parsedDocumentReference = new FhirParseService().parseResource(jsonInput, DocumentReference.class);
@@ -185,7 +185,7 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
     }
 
     @Test
-    void When_DocumentReferenceJsonNotPopulatedWithNoPat_Expect_NarrativeStatementDoesNotPopulateReferredToExternalDocumentWithNopat() {
+    void When_DocReferenceJsonNotPopulatedWithNoPat_Expect_NarrativeStatementDoesNotPopulateReferredToExternalDocumentWithNopat() {
 
         final String jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_OPTIONAL_DATA);
         final DocumentReference parsedDocumentReference = new FhirParseService().parseResource(jsonInput, DocumentReference.class);
@@ -197,7 +197,7 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
 
     @ParameterizedTest
     @MethodSource("documentReferenceResourceFileParams")
-    void When_MappingDocumentReferenceJson_Expect_NarrativeStatementXmlOutput(String inputJson, String outputXml) {
+    void When_MappingDocReferenceJson_Expect_NarrativeStatementXmlOutput(String inputJson, String outputXml) {
 
         final CharSequence expectedOutputMessage = ResourceTestFileUtils.getFileContent(outputXml);
         final String jsonInput = ResourceTestFileUtils.getFileContent(inputJson);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
@@ -46,37 +46,37 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
         = TEST_FILE_DIRECTORY + "example-document-reference-resource-with-nopat-security-15.json";
     private static final String INPUT_JSON_WITH_TYPE_TEXT_ONLY = TEST_FILE_DIRECTORY + "example-document-reference-resource-2.json";
     private static final String INPUT_JSON_WITH_TYPE_DISPLAY_ONLY = TEST_FILE_DIRECTORY + "example-document-reference-resource-3.json";
-    private static final String INPUT_JSON_WITH_AVAILABILITY_TIME_CREATED = TEST_FILE_DIRECTORY
-                                                                            + "example-document-reference-resource-4.json";
+    private static final String INPUT_JSON_WITH_AVAILABILITY_TIME_CREATED
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-4.json";
     private static final String INPUT_JSON_WITH_AUTHOR_ORGANISATION = TEST_FILE_DIRECTORY + "example-document-reference-resource-5.json";
     private static final String INPUT_JSON_WITH_CUSTODIAN_AND_ORG_NAME = TEST_FILE_DIRECTORY + "example-document-reference-resource-6.json";
     private static final String INPUT_JSON_WITH_DESCRIPTION = TEST_FILE_DIRECTORY + "example-document-reference-resource-7.json";
-    private static final String INPUT_JSON_WITH_PRACTICE_SETTING_TEXT_ONLY = TEST_FILE_DIRECTORY
-                                                                             + "example-document-reference-resource-8.json";
-    private static final String INPUT_JSON_WITH_PRACTICE_SETTING_DISPLAY_ONLY = TEST_FILE_DIRECTORY
-                                                                                + "example-document-reference-resource-9.json";
+    private static final String INPUT_JSON_WITH_PRACTICE_SETTING_TEXT_ONLY
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-8.json";
+    private static final String INPUT_JSON_WITH_PRACTICE_SETTING_DISPLAY_ONLY
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-9.json";
     private static final String INPUT_JSON_WITH_ATTACHMENT_TITLE = TEST_FILE_DIRECTORY + "example-document-reference-resource-10.json";
     private static final String INPUT_JSON_REQUIRED_DATA = TEST_FILE_DIRECTORY + "example-document-reference-resource-11.json";
-    private static final String INPUT_JSON_WITH_CUSTODIAN_AND_NO_ORG_NAME = TEST_FILE_DIRECTORY
-                                                                            + "example-document-reference-resource-12.json";
+    private static final String INPUT_JSON_WITH_CUSTODIAN_AND_NO_ORG_NAME
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-12.json";
     private static final String INPUT_JSON_WITH_AUTHOR_PRACTITIONER = TEST_FILE_DIRECTORY + "example-document-reference-resource-13.json";
-    private static final String INPUT_JSON_WITH_NOT_SUPPORTED_CONTENT_TYPE = TEST_FILE_DIRECTORY
-                                                                             + "example-document-reference-resource-14.json";
+    private static final String INPUT_JSON_WITH_NOT_SUPPORTED_CONTENT_TYPE
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-14.json";
 
     private static final String OUTPUT_XML_OPTIONAL_DATA = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-1.xml";
     private static final String OUTPUT_XML_WITH_TYPE_TEXT_ONLY = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-2.xml";
     private static final String OUTPUT_XML_WITH_TYPE_DISPLAY_ONLY = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-3.xml";
-    private static final String OUTPUT_XML_WITH_AVAILABILITY_TIME_CREATED = TEST_FILE_DIRECTORY
-                                                                            + "expected-output-narrative-statement-4.xml";
+    private static final String OUTPUT_XML_WITH_AVAILABILITY_TIME_CREATED
+        = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-4.xml";
     private static final String OUTPUT_XML_WITH_AUTHOR_ORGANISATION = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-5.xml";
     private static final String OUTPUT_XML_WITH_CUSTODIAN_ORG_NAME = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-6.xml";
     private static final String OUTPUT_XML_WITH_DESCRIPTION = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-7.xml";
-    private static final String OUTPUT_XML_WITH_PRACTICE_SETTING_TEXT_ONLY = TEST_FILE_DIRECTORY
-                                                                             + "expected-output-narrative-statement-8.xml";
-    private static final String OUTPUT_XML_WITH_PRACTICE_SETTING_DISPLAY_ONLY = TEST_FILE_DIRECTORY
-                                                                                + "expected-output-narrative-statement-9.xml";
-    private static final String OUTPUT_XML_WITH_ABSENT_ATTACHMENT_TITLE = TEST_FILE_DIRECTORY
-                                                                          + "expected-output-narrative-statement-10.xml";
+    private static final String OUTPUT_XML_WITH_PRACTICE_SETTING_TEXT_ONLY
+        = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-8.xml";
+    private static final String OUTPUT_XML_WITH_PRACTICE_SETTING_DISPLAY_ONLY
+        = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-9.xml";
+    private static final String OUTPUT_XML_WITH_ABSENT_ATTACHMENT_TITLE
+        = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-10.xml";
     private static final String OUTPUT_XML_REQUIRED_DATA = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-11.xml";
     private static final String OUTPUT_XML_NOT_SUPPORTED_CONTENT_TYPE = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-12.xml";
     public static final String NARRATIVE_STATEMENT_REFERENCE_CONFIDENTIALITY_CODE_XPATH =

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapperTest.java
@@ -39,49 +39,49 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
 
     private static final String INPUT_JSON_OPTIONAL_DATA = TEST_FILE_DIRECTORY + "example-document-reference-resource-1.json";
     private static final String INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY_AND_SECURITY_LABEL_BUT_WITHOUT_NOPAT
-                                        = TEST_FILE_DIRECTORY + "example-document-reference-resource-with-nopat-security-label-17.json";
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-with-nopat-security-label-17.json";
     private static final String INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY_LABEL
-                                        = TEST_FILE_DIRECTORY + "example-document-reference-resource-with-nopat-security-label-16.json";
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-with-nopat-security-label-16.json";
     private static final String INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY
-                                        = TEST_FILE_DIRECTORY + "example-document-reference-resource-with-nopat-security-15.json";
+        = TEST_FILE_DIRECTORY + "example-document-reference-resource-with-nopat-security-15.json";
     private static final String INPUT_JSON_WITH_TYPE_TEXT_ONLY = TEST_FILE_DIRECTORY + "example-document-reference-resource-2.json";
     private static final String INPUT_JSON_WITH_TYPE_DISPLAY_ONLY = TEST_FILE_DIRECTORY + "example-document-reference-resource-3.json";
     private static final String INPUT_JSON_WITH_AVAILABILITY_TIME_CREATED = TEST_FILE_DIRECTORY
-                                                                                        + "example-document-reference-resource-4.json";
+                                                                            + "example-document-reference-resource-4.json";
     private static final String INPUT_JSON_WITH_AUTHOR_ORGANISATION = TEST_FILE_DIRECTORY + "example-document-reference-resource-5.json";
     private static final String INPUT_JSON_WITH_CUSTODIAN_AND_ORG_NAME = TEST_FILE_DIRECTORY + "example-document-reference-resource-6.json";
     private static final String INPUT_JSON_WITH_DESCRIPTION = TEST_FILE_DIRECTORY + "example-document-reference-resource-7.json";
     private static final String INPUT_JSON_WITH_PRACTICE_SETTING_TEXT_ONLY = TEST_FILE_DIRECTORY
-        + "example-document-reference-resource-8.json";
+                                                                             + "example-document-reference-resource-8.json";
     private static final String INPUT_JSON_WITH_PRACTICE_SETTING_DISPLAY_ONLY = TEST_FILE_DIRECTORY
-        + "example-document-reference-resource-9.json";
+                                                                                + "example-document-reference-resource-9.json";
     private static final String INPUT_JSON_WITH_ATTACHMENT_TITLE = TEST_FILE_DIRECTORY + "example-document-reference-resource-10.json";
     private static final String INPUT_JSON_REQUIRED_DATA = TEST_FILE_DIRECTORY + "example-document-reference-resource-11.json";
     private static final String INPUT_JSON_WITH_CUSTODIAN_AND_NO_ORG_NAME = TEST_FILE_DIRECTORY
-        + "example-document-reference-resource-12.json";
+                                                                            + "example-document-reference-resource-12.json";
     private static final String INPUT_JSON_WITH_AUTHOR_PRACTITIONER = TEST_FILE_DIRECTORY + "example-document-reference-resource-13.json";
     private static final String INPUT_JSON_WITH_NOT_SUPPORTED_CONTENT_TYPE = TEST_FILE_DIRECTORY
-        + "example-document-reference-resource-14.json";
+                                                                             + "example-document-reference-resource-14.json";
 
     private static final String OUTPUT_XML_OPTIONAL_DATA = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-1.xml";
     private static final String OUTPUT_XML_WITH_TYPE_TEXT_ONLY = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-2.xml";
     private static final String OUTPUT_XML_WITH_TYPE_DISPLAY_ONLY = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-3.xml";
     private static final String OUTPUT_XML_WITH_AVAILABILITY_TIME_CREATED = TEST_FILE_DIRECTORY
-        + "expected-output-narrative-statement-4.xml";
+                                                                            + "expected-output-narrative-statement-4.xml";
     private static final String OUTPUT_XML_WITH_AUTHOR_ORGANISATION = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-5.xml";
     private static final String OUTPUT_XML_WITH_CUSTODIAN_ORG_NAME = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-6.xml";
     private static final String OUTPUT_XML_WITH_DESCRIPTION = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-7.xml";
     private static final String OUTPUT_XML_WITH_PRACTICE_SETTING_TEXT_ONLY = TEST_FILE_DIRECTORY
-        + "expected-output-narrative-statement-8.xml";
+                                                                             + "expected-output-narrative-statement-8.xml";
     private static final String OUTPUT_XML_WITH_PRACTICE_SETTING_DISPLAY_ONLY = TEST_FILE_DIRECTORY
-        + "expected-output-narrative-statement-9.xml";
+                                                                                + "expected-output-narrative-statement-9.xml";
     private static final String OUTPUT_XML_WITH_ABSENT_ATTACHMENT_TITLE = TEST_FILE_DIRECTORY
-        + "expected-output-narrative-statement-10.xml";
+                                                                          + "expected-output-narrative-statement-10.xml";
     private static final String OUTPUT_XML_REQUIRED_DATA = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-11.xml";
     private static final String OUTPUT_XML_NOT_SUPPORTED_CONTENT_TYPE = TEST_FILE_DIRECTORY + "expected-output-narrative-statement-12.xml";
     public static final String NARRATIVE_STATEMENT_REFERENCE_CONFIDENTIALITY_CODE_XPATH =
-                                "/component/NarrativeStatement/reference/referredToExternalDocument/"
-                                + ConfidentialityCodeUtility.getNopatConfidentialityCodeXpathSegment();
+        "/component/NarrativeStatement/reference/referredToExternalDocument/"
+        + ConfidentialityCodeUtility.getNopatConfidentialityCodeXpathSegment();
 
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
@@ -149,7 +149,7 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
     }
 
     @Test
-    void When_DocRefSecurityLabelPopulatedWithNoPatAndNotReductionType_Expect_NarrativeStatementReferredToExternalDocIsNotPopulated() {
+    void When_DocRefSecurityLabelPopulatedWithNoPatAndNotReduction_Expect_NarrativeStatementReferredToExternalDocIsNotPopulated() {
 
         final String jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY_LABEL);
         final DocumentReference parsedDocumentReference = new FhirParseService().parseResource(jsonInput, DocumentReference.class);
@@ -173,7 +173,7 @@ public class DocumentReferenceToNarrativeStatementMapperTest {
     }
 
     @Test
-    void When_DocReferenceJsonPopulatedWithNoPatAndNotReductionType_Expect_NarrativeStatementDoesNotPopulateReferredToExternalDoc() {
+    void When_DocReferenceJsonPopulatedWithNoPatAndNotReduction_Expect_NarrativeStatementDoesNotPopulateReferredToExternalDoc() {
 
         final String jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_OPTIONAL_DATA_WITH_NOPAT_WITH_SECURITY);
         final DocumentReference parsedDocumentReference = new FhirParseService().parseResource(jsonInput, DocumentReference.class);

--- a/service/src/test/resources/ehr/mapper/documentreference/example-document-reference-resource-with-nopat-security-label-16.json
+++ b/service/src/test/resources/ehr/mapper/documentreference/example-document-reference-resource-with-nopat-security-label-16.json
@@ -1,0 +1,69 @@
+{
+  "resourceType": "DocumentReference",
+  "id": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66",
+  "meta": {
+    "versionId": "5774557612980378259",
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+    ]
+  },
+  "securityLabel": [
+    {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/v3/ActCode",
+          "code": "NOPAT",
+          "display": "no disclosure to patient, family or caregivers without attending provider's authorization"
+        }
+      ],
+      "text": "no disclosure to patient, family or caregivers without attending provider's authorization"
+    }
+  ],
+  "identifier": [
+    {
+      "system": "https://EMISWeb/A82038",
+      "value": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66"
+    }
+  ],
+  "status": "current",
+  "type": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "25611000000107",
+        "display": "Referral letter",
+        "userSelected": true
+      }
+    ],
+    "text": "Referral Letter (21-Sep-2020)"
+  },
+  "created": "2020-09-21",
+  "indexed": "2020-09-21T14:17:59.607+01:00",
+  "custodian": {
+    "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+  },
+  "content": [
+    {
+      "attachment": {
+        "contentType": "text/richtext",
+        "title": "some title"
+      }
+    }
+  ],
+  "description": "for 2 week rule referral - skin",
+  "author": [
+    {
+      "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+    }
+  ],
+  "context": {
+    "practiceSetting": {
+      "coding": [
+        {
+          "display": "Practice Setting Display"
+        }
+      ],
+      "text": "Practice Setting Text"
+    }
+  }
+}

--- a/service/src/test/resources/ehr/mapper/documentreference/example-document-reference-resource-with-nopat-security-label-17.json
+++ b/service/src/test/resources/ehr/mapper/documentreference/example-document-reference-resource-with-nopat-security-label-17.json
@@ -1,0 +1,74 @@
+{
+  "resourceType": "DocumentReference",
+  "id": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66",
+  "meta": {
+    "versionId": "5774557612980378259",
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
+    ],
+    "security": [{
+      "system":"http://hl7.org/fhir/v3/ActCode",
+      "code":"RWR",
+      "display":"Received written"
+    }]
+  },
+  "securityLabel": [
+    {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/v3/ActCode",
+          "code": "RWR",
+          "display": "Received written"
+        }
+      ],
+      "text": "no disclosure to patient, family or caregivers without attending provider's authorization"
+    }
+  ],
+  "identifier": [
+    {
+      "system": "https://EMISWeb/A82038",
+      "value": "AECD4BBE-F45C-42A0-BB77-AB77BAEE3E66"
+    }
+  ],
+  "status": "current",
+  "type": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "25611000000107",
+        "display": "Referral letter",
+        "userSelected": true
+      }
+    ],
+    "text": "Referral Letter (21-Sep-2020)"
+  },
+  "created": "2020-09-21",
+  "indexed": "2020-09-21T14:17:59.607+01:00",
+  "custodian": {
+    "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+  },
+  "content": [
+    {
+      "attachment": {
+        "contentType": "text/richtext",
+        "title": "some title"
+      }
+    }
+  ],
+  "description": "for 2 week rule referral - skin",
+  "author": [
+    {
+      "reference": "Organization/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+    }
+  ],
+  "context": {
+    "practiceSetting": {
+      "coding": [
+        {
+          "display": "Practice Setting Display"
+        }
+      ],
+      "text": "Practice Setting Text"
+    }
+  }
+}


### PR DESCRIPTION
## What

NOPAT SecurityLabels and Meta Security has been added  to ReferredToExternalDocument

## Why

When securityLabel and meta security include NOPAT then confidentialityCode should be added to ReferredToExternalDocument section.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
