### PR TITLE
Removing a variable that is not used atm

### DIFF
--- a/service/src/intTest/resources/application.yml
+++ b/service/src/intTest/resources/application.yml
@@ -14,7 +14,7 @@ management:
         include: info, health, metrics
 
 gp2gp:
-  ehr-extract-sent-days-limit: ${EHR_EXTRACT_SENT_DAYS_LIMIT:8}
+  ehr-extract-sent-days-limit: 8
   redactions-enabled: ${GP2GP_REDACTIONS_ENABLED:false}
   largeAttachmentThreshold: ${GP2GP_LARGE_ATTACHMENT_THRESHOLD:4500000} # value in bytes. Default value for Spine is ~4.5MB
   largeEhrExtractThreshold: ${GP2GP_LARGE_ATTACHMENT_THRESHOLD:4500000}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ management:
         include: info, health, metrics, mappings
 
 gp2gp:
-  ehr-extract-sent-days-limit: ${EHR_EXTRACT_SENT_DAYS_LIMIT:8}
+  ehr-extract-sent-days-limit: 8
   redactions-enabled: ${GP2GP_REDACTIONS_ENABLED:false}
   largeAttachmentThreshold: ${GP2GP_LARGE_ATTACHMENT_THRESHOLD:4500000} # value in bytes. Default value for Spine is ~4.5MB
   largeEhrExtractThreshold: ${GP2GP_LARGE_EHR_EXTRACT_THRESHOLD:4500000}


### PR DESCRIPTION
## What

Removing EHR_EXTRACT_SENT_DAYS_LIMIT variable that is not used at the moment

## Why

At the moment EHR_EXTRACT_SENT_DAYS_LIMIT that is setup in application.yml is not used hence removing it for now

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
