### PR TITLE
Fix issues with deprecated `setBlackList` and `setWhiteList` and use `setAllowList` and `setDenyList` methods instead.

### DIFF
--- a/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/configurations/AmqpConfiguration.java
+++ b/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/configurations/AmqpConfiguration.java
@@ -56,11 +56,11 @@ public class AmqpConfiguration {
             (JmsDefaultDeserializationPolicy) factory.getDeserializationPolicy();
 
         if (StringUtils.isNotBlank(properties.getDeserializationPolicy().getWhiteList())) {
-            deserializationPolicy.setWhiteList(properties.getDeserializationPolicy().getWhiteList());
+            deserializationPolicy.setAllowList(properties.getDeserializationPolicy().getWhiteList());
         }
 
         if (StringUtils.isNotBlank(properties.getDeserializationPolicy().getBlackList())) {
-            deserializationPolicy.setBlackList(properties.getDeserializationPolicy().getBlackList());
+            deserializationPolicy.setDenyList(properties.getDeserializationPolicy().getBlackList());
         }
     }
 


### PR DESCRIPTION
## What

Fix issues with deprecated `setBlackList` and `setWhiteList` and use `setAllowList` and `setDenyList` methods instead.

## Why

![image](https://github.com/user-attachments/assets/3bcedc78-5115-4599-9b53-0fbfa0651788)

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
