### PR TITLE
Fix issue with nullability checking in `ResourceReader`

### DIFF
--- a/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/common/ResourceReader.java
+++ b/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/common/ResourceReader.java
@@ -2,6 +2,7 @@ package uk.nhs.adaptors.mockmhsservice.common;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import lombok.SneakyThrows;
 
@@ -9,7 +10,7 @@ public class ResourceReader {
     @SneakyThrows
     public static String readAsString(String resourceName) {
         try (InputStream inputStream = ResourceReader.class.getResourceAsStream(String.format("/%s",resourceName))) {
-            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(Objects.requireNonNull(inputStream).readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 }


### PR DESCRIPTION

## What

Added `Objects.requireNonNull` to wrap the `inputStream` so that a nullable stream is not passed to an explicitly `nonNull`  method parameter.

## Why

The method `readAsString` was using an input string which was marked as @Nullable, in method parameter marked as @NotNull.  Although this should never happen, based on the code which uses it, but we need to address the potential nullPointerException

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

