### PR TITLE
Fix issue with auto-closable instance not being used in a try-with-resources statement 

### DIFF
--- a/e2e-tests/src/main/java/uk/nhs/adaptors/gp2gp/Mongo.java
+++ b/e2e-tests/src/main/java/uk/nhs/adaptors/gp2gp/Mongo.java
@@ -29,9 +29,9 @@ public class Mongo {
             var connectionString = System.getenv().getOrDefault("GP2GP_MONGO_URI", "mongodb://localhost:27017");
             var database = System.getenv().getOrDefault("GP2GP_MONGO_DATABASE_NAME", "gp2gp");
 
-                var client = create(connectionString);
+            try(var client = create(connectionString)) {
                 sharedDatabaseConnection = client.getDatabase(database);
-
+            }
         }
         return sharedDatabaseConnection;
     }


### PR DESCRIPTION

## What

Fix issue with resource management in client creation in `Mongo.java`, where the mongo client is is created to retrieve the database connection, but is not auto-closed when required.

## Why

Fix issue with auto-closable instance not being used in a try-with-resources statement which should be used when developing in Java 7 or higher

![image](https://github.com/user-attachments/assets/31c6f9c4-172b-4ad2-b236-273d6d9a633a)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
