### PR TITLE
NIAD-3204: Allow sending an ehrComposition without an author/Participant2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the resultant XML will no longer contain the superfluous 'Earliest Recall Date: <startDate>' value.
 * When mapping `ProcedureRequests` with a `requestor` referencing a `device` without a `manufacturer` a spurious 
   `"null"` is no longer output in the generated `"Recall Device:"` text.
+* When mapping an `Encounter` without a Recorder `participant`, now send the author as `nulFlavor=UNK`.
+  Previously this would raise the error "EhrMapperException: Encounter.participant recorder is required" and send a
+  failure to the requesting system.
 
 ### Added
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
@@ -73,10 +73,9 @@ public class EncounterMapper {
             .originalText(buildOriginalText(encounter))
             .locationName(buildLocationPertinentInformation(encounter));
 
-        final String recReference = findParticipantWithCoding(encounter, ParticipantCoding.RECORDER)
-            .map(agentDirectory::getAgentId)
-            .orElseThrow(() -> new EhrMapperException("Encounter.participant recorder is required"));
-        encounterStatementTemplateParameters.author(recReference);
+        final Optional<String> recReference = findParticipantWithCoding(encounter, ParticipantCoding.RECORDER)
+            .map(agentDirectory::getAgentId);
+        recReference.map(encounterStatementTemplateParameters::author);
 
         messageContext.getInputBundleHolder()
             .getListReferencedToEncounter(encounter.getIdElement(), CONSULTATION_LIST_CODE)
@@ -88,7 +87,7 @@ public class EncounterMapper {
         final Optional<String> pprfReference = findParticipantWithCoding(encounter, ParticipantCoding.PERFORMER)
             .map(agentDirectory::getAgentId);
 
-        encounterStatementTemplateParameters.participant2(pprfReference.orElse(recReference));
+        encounterStatementTemplateParameters.participant2(pprfReference.orElse(recReference.orElse(null)));
 
         updateEhrFolderEffectiveTime(encounter);
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapperTest.java
@@ -127,6 +127,7 @@ public class EncounterMapperTest {
         + "example-encounter-resource-18.json";
     private static final String OUTPUT_XML_WITH_NO_EHR_COMPOSITION_COMPONENTS = TEST_FILES_DIRECTORY
         + "expected-output-encounter-14.xml";
+    public static final String OUTPUT_XML_WITH_NUL_AUTHOR_PARTICIPANT2 = TEST_FILES_DIRECTORY + "expected-output-encounter-15.xml";
 
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
@@ -159,7 +160,7 @@ public class EncounterMapperTest {
     @ParameterizedTest
     @MethodSource("testFilePaths")
     public void When_MappingParsedEncounterJson_Expect_EhrCompositionXmlOutput(String input, String output) throws IOException {
-        when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
+        lenient().when(randomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
         var sampleComponent = ResourceTestFileUtils.getFileContent(SAMPLE_EHR_COMPOSITION_COMPONENT);
 
         String expectedOutputMessage = ResourceTestFileUtils.getFileContent(output);
@@ -189,6 +190,7 @@ public class EncounterMapperTest {
             Arguments.of(INPUT_JSON_WITH_TYPE_AND_NO_CODING_AND_TEXT, OUTPUT_XML_WITH_TYPE_AND_NO_CODING_AND_TEXT),
             Arguments.of(INPUT_JSON_WITH_TYPE_AND_NO_CODING_AND_TEXT_AND_NO_TEXT, OUTPUT_XML_WITH_TYPE_AND_NO_CODING_AND_TEXT_AND_NO_TEXT),
             Arguments.of(INPUT_JSON_WITHOUT_PERFORMER_PARTICIPANT, OUTPUT_XML_WITH_RECORDER_AS_PARTICIPANT2),
+            Arguments.of(INPUT_JSON_WITHOUT_RECORDER_PARTICIPANT, OUTPUT_XML_WITH_NUL_AUTHOR_PARTICIPANT2),
             Arguments.of(INPUT_JSON_WITH_NO_LOCATION_REFERENCE, OUTPUT_XML_WITH_NO_LOCATION_REFERENCE)
         );
     }
@@ -221,21 +223,6 @@ public class EncounterMapperTest {
         assertThatThrownBy(() -> encounterMapper.mapEncounterToEhrComposition(parsedEncounter))
             .isExactlyInstanceOf(EhrMapperException.class)
             .hasMessage("Not supported agent reference: Patient/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73");
-    }
-
-    @Test
-    public void When_MappingEncounterWithoutRecorderParticipant_Expect_Exception() throws IOException {
-        var sampleComponent = ResourceTestFileUtils.getFileContent(SAMPLE_EHR_COMPOSITION_COMPONENT);
-
-        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITHOUT_RECORDER_PARTICIPANT);
-
-        Encounter parsedEncounter = new FhirParseService().parseResource(jsonInput, Encounter.class);
-
-        when(encounterComponentsMapper.mapComponents(parsedEncounter)).thenReturn(sampleComponent);
-
-        assertThatThrownBy(() -> encounterMapper.mapEncounterToEhrComposition(parsedEncounter))
-            .isExactlyInstanceOf(EhrMapperException.class)
-            .hasMessage("Encounter.participant recorder is required");
     }
 
     @Test

--- a/service/src/test/resources/ehr/mapper/encounter/example-encounter-resource-14.json
+++ b/service/src/test/resources/ehr/mapper/encounter/example-encounter-resource-14.json
@@ -28,24 +28,7 @@
   "subject":{
     "reference":"Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
   },
-  "participant":[
-    {
-      "type":[
-        {
-          "coding":[
-            {
-              "system":"http://hl7.org/fhir/v3/ParticipationType",
-              "code":"PPRF",
-              "display":"primary performer"
-            }
-          ]
-        }
-      ],
-      "individual":{
-        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
-      }
-    }
-  ],
+  "participant":[],
   "period":{
     "start":"2010-01-13T15:20:00+00:00",
     "end":"2010-01-13T16:20:00+00:00"

--- a/service/src/test/resources/ehr/mapper/encounter/expected-output-encounter-15.xml
+++ b/service/src/test/resources/ehr/mapper/encounter/expected-output-encounter-15.xml
@@ -1,0 +1,59 @@
+<component typeCode="COMP">
+    <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+        <id root="test-id" />
+        <code code="24561000000109" displayName="A+E report" codeSystem="2.16.840.1.113883.2.1.3.2.4.15">
+            <originalText>GP Surgery</originalText>
+        </code>
+        <statusCode code="COMPLETE" />
+        <effectiveTime>
+            <low value="20100113152000"/><high value="20100113162000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152000"/>
+        <author typeCode="AUT" contextControlCode="OP">
+            <time value="20100113151332" />
+            <agentRef classCode="AGNT">
+                <id nullFlavor="UNK" />
+            </agentRef>
+        </author>
+        <location typeCode="LOC">
+            <locatedEntity classCode="LOCE">
+                <code code="394730007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Healthcare related organisation" />
+                <locatedPlace classCode="PLC" determinerCode="INSTANCE">
+                    <name>Test Location</name>
+                </locatedPlace>
+            </locatedEntity>
+        </location>
+        <Participant2 typeCode="PRF" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id nullFlavor="UNK" />
+            </agentRef>
+        </Participant2>
+        <component typeCode="COMP" >
+            <ObservationStatement classCode="OBS" moodCode="EVN">
+                <id root="BA6EA7CB-3E2F-46FA-918C-C0B5178C1D4E" />
+                <code code="907511000006105" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="[RFC] Chest infection">
+                    <originalText>Test</originalText>
+                </code>
+                <statusCode code="COMPLETE" />
+                <effectiveTime>
+                    <center value="20201110115000"/>
+                </effectiveTime>
+                <availabilityTime value="20201110115000"/>
+
+
+                <pertinentInformation typeCode="PERT">
+                    <sequenceNumber value="+1" />
+                    <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                        <text>Test Observation</text>
+                    </pertinentAnnotation>
+                </pertinentInformation>
+
+                <Participant typeCode="PRF" contextControlCode="OP">
+                    <agentRef classCode="AGNT">
+                        <id root="6423EA0F-1F1C-4255-AEBA-D142BE836D50"/>
+                    </agentRef>
+                </Participant>
+            </ObservationStatement>
+        </component>
+    </ehrComposition>
+</component>


### PR DESCRIPTION
## Why

Having done some testing with other GP2GP implementations we've identified that other systems will accept this and generate a fake placeholder Dr within their system when ingesting the record.

While the GP Connect spec insists that an Encounter has a participant of type REC, it is preferable to send a GP2GP extract than fail the transfer completely.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
