### PR TITLE
NIAD-3211: Allow sending a `linkset` without a `Participant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* When mapping a `Condition` without an `asserter`, omit the `Participant` element within the XML.
+  Previously this would raise the error "EhrMapperException: Condition.asserter is required" and send a
+  failure to the requesting system.
+
 * When mapping a `DocumentReference` which contains a `NOPAT` `meta.security` or `NOPAT` `securityLabel` tag the resultant XML for that resource
   will contain a `NOPAT` `confidentialityCode` element.
 * When mapping `AllergyIntolerances` which contain a `NOPAT` `meta.security` tag the resultant XML for that resource

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ConditionLinkSetMapperTest.java
@@ -108,6 +108,7 @@ class ConditionLinkSetMapperTest {
     private static final String OUTPUT_XML_WITH_NULL_FLAVOR_OBSERVATION_STATEMENT_AVAILABILITY_TIME = EXPECTED_OUTPUT_LINKSET + "18.xml";
     private static final String OUTPUT_XML_WITH_STATEMENT_REF_LINK_ALLERGY_OBSERVATION = EXPECTED_OUTPUT_LINKSET + "19.xml";
     private static final String OUTPUT_XML_MEDICATION_REQUEST_ACTUAL_PROBLEM = EXPECTED_OUTPUT_LINKSET + "20.xml";
+    private static final String OUTPUT_XML_NO_PARTICIPANT = EXPECTED_OUTPUT_LINKSET + "21.xml";
 
     @Mock
     private IdMapper idMapper;
@@ -171,15 +172,6 @@ class ConditionLinkSetMapperTest {
 
         assertThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(condition, false))
             .isSameAs(propagatedException);
-    }
-
-    @Test
-    void When_MappingParsedConditionWithoutAsserter_Expect_EhrMapperException() {
-        final Condition condition = getConditionResourceFromJson(INPUT_JSON_ASSERTER_NOT_PRESENT);
-
-        assertThatThrownBy(() -> conditionLinkSetMapper.mapConditionToLinkSet(condition, false))
-            .isExactlyInstanceOf(EhrMapperException.class)
-            .hasMessage("Condition.asserter is required");
     }
 
     @Test
@@ -307,6 +299,7 @@ class ConditionLinkSetMapperTest {
             Arguments.of(INPUT_JSON_STATUS_INACTIVE, OUTPUT_XML_WITH_STATUS_INACTIVE, false),
             Arguments.of(INPUT_JSON_DATES_PRESENT, OUTPUT_XML_WITH_DATES_PRESENT, false),
             Arguments.of(INPUT_JSON_DATES_NOT_PRESENT, OUTPUT_XML_WITH_DATES_NOT_PRESENT, false),
+            Arguments.of(INPUT_JSON_ASSERTER_NOT_PRESENT, OUTPUT_XML_NO_PARTICIPANT, false),
             Arguments.of(INPUT_JSON_RELATED_CLINICAL_CONTENT_LIST_REFERENCE, OUTPUT_XML_WITH_NO_RELATED_CLINICAL_CONTENT, false),
             Arguments.of(INPUT_JSON_WITH_ACTUAL_PROBLEM_ALLERGY_INTOLERANCE, OUTPUT_XML_ALLERGY_INTOLERANCE_ACTUAL_PROBLEM, false),
             Arguments.of(INPUT_JSON_WITH_ACTUAL_PROBLEM_IMMUNIZATION, OUTPUT_XML_IMMUNIZATION_ACTUAL_PROBLEM, false),

--- a/service/src/test/resources/ehr/mapper/condition/expected_output_linkset_21.xml
+++ b/service/src/test/resources/ehr/mapper/condition/expected_output_linkset_21.xml
@@ -1,0 +1,37 @@
+<component typeCode="COMP">
+    <LinkSet classCode="OBS" moodCode="EVN">
+        <id root="7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB-PROB" />
+        <code code="394775005" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Inactive Problem">
+            <originalText>Inactive Problem, minor</originalText>
+            <qualifier inverted="false">
+                <name code="394847000" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Unspecified significance"/>
+            </qualifier>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20200906"/>
+            <high value="20201004000000"/>
+        </effectiveTime>
+        <availabilityTime value="20200907101202" />
+            <component typeCode="COMP">
+                <statementRef classCode="OBS" moodCode="EVN">
+                    <id root="D2EA00FC-7B85-46C5-A0B7-E49C53C054D0-Condition-new-ID"/>
+                </statementRef>
+            </component>
+            <component typeCode="COMP">
+                <statementRef classCode="OBS" moodCode="EVN">
+                    <id root="82A9E6C8-20CE-48DA-B6B3-15C39E5ABB5E-Condition-new-ID"/>
+                </statementRef>
+            </component>
+            <component typeCode="COMP">
+                <statementRef classCode="OBS" moodCode="EVN">
+                    <id root="8747DFC5-11B7-4A77-B2F3-7720CC58C2FC-Condition-new-ID"/>
+                </statementRef>
+            </component>
+        <conditionNamed typeCode="NAME" inversionInd="true">
+            <namedStatementRef classCode="OBS" moodCode="EVN">
+                <id root="7E277DF1-6F1C-47CD-84F7-E9B7BF4105DB-Condition-new-ID"/>
+            </namedStatementRef>
+        </conditionNamed>
+    </LinkSet>
+</component>


### PR DESCRIPTION
## Why

Having done some testing with other GP2GP implementations we've identified that other systems will accept this and optionally generate a fake placeholder Dr within their system when ingesting the record.

While the GP Connect spec insists that a Problem Header (Condition) has an asserter, it is preferable to send the GP2GP extract than fail the transfer completely.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
