### PR TITLE
NIAD-3211: Allow sending a MedicationStatement without a Participant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When mapping a `Condition` without an `asserter`, omit the `Participant` element within the XML.
   Previously this would raise the error "EhrMapperException: Condition.asserter is required" and send a
   failure to the requesting system.
+* When mapping a `MedicationRequest` without a `recorder` or `requester`, omit the `Participant` element within the XML.
+  Previously this would raise the error "MedicationRequest ... missing recorder of type Practitioner, PractitionerRole
+  or Organization" and send a failure to the requesting system.
 
 * When mapping a `DocumentReference` which contains a `NOPAT` `meta.security` or `NOPAT` `securityLabel` tag the resultant XML for that resource
   will contain a `NOPAT` `confidentialityCode` element.

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
@@ -299,8 +299,7 @@ public class MedicationStatementMapper {
                     messageContext.getAgentDirectory().getAgentId(reference), ParticipantType.AUTHOR);
             }
         }
-        throw new EhrMapperException("MedicationRequest " + medicationRequest.getId()
-            + " missing recorder of type Practitioner, PractitionerRole or Organization");
+        return StringUtils.EMPTY;
     }
 
     private static Predicate<Reference> buildPredicateReferenceIsA(@NonNull ResourceType type) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
@@ -134,6 +134,8 @@ public class MedicationStatementMapperTest {
         + "medication-request-with-extension-status-reason-with-text.json";
     private static final String OUTPUT_XML_WITH_STATUS_REASON_TEXT = TEST_FILE_DIRECTORY
         + "medication-statement-with-status-reason-text.xml";
+    private static final String OUTPUT_XML_WITH_NO_PARTICIPANT = TEST_FILE_DIRECTORY
+            + "medication-statement-with-no-participant.xml";
     private static final String INPUT_JSON_WITH_REQUESTER_ON_BEHALF_OF = TEST_FILE_DIRECTORY
         + "medication-request-with-requester-on-behalf-of.json";
     private static final String INPUT_JSON_WITH_REQUESTER = TEST_FILE_DIRECTORY
@@ -230,7 +232,9 @@ public class MedicationStatementMapperTest {
             Arguments.of(INPUT_JSON_WITH_PLAN_NO_OPTIONAL_FIELDS, OUTPUT_XML_WITH_AUTHORISE_NO_OPTIONAL_FIELDS),
             Arguments.of(INPUT_JSON_WITH_PLAN_NO_STATUS_REASON_CODE, OUTPUT_XML_WITH_AUTHORISE_DEFAULT_STATUS_REASON_CODE),
             Arguments.of(INPUT_JSON_WITH_PLAN_NO_INFO_PRESCRIPTION_TEXT, OUTPUT_XML_WITH_AUTHORISE_REPEAT_PRESCRIPTION),
-            Arguments.of(INPUT_JSON_WITH_EXTENSION_STATUS_REASON_TEXT, OUTPUT_XML_WITH_STATUS_REASON_TEXT)
+            Arguments.of(INPUT_JSON_WITH_EXTENSION_STATUS_REASON_TEXT, OUTPUT_XML_WITH_STATUS_REASON_TEXT),
+            Arguments.of(INPUT_JSON_WITH_NO_RECORDER_REFERENCE, OUTPUT_XML_WITH_NO_PARTICIPANT),
+            Arguments.of(INPUT_JSON_WITH_INVALID_RECORDER_REFERENCE_TYPE, OUTPUT_XML_WITH_NO_PARTICIPANT)
         );
     }
 
@@ -242,7 +246,7 @@ public class MedicationStatementMapperTest {
 
         String outputMessage = medicationStatementMapper.mapMedicationRequestToMedicationStatement(parsedMedicationRequest);
 
-        assertThat(outputMessage).isEqualTo(expected);
+        assertThat(outputMessage).isEqualToNormalizingWhitespace(expected);
     }
 
     @SneakyThrows
@@ -293,9 +297,7 @@ public class MedicationStatementMapperTest {
             INPUT_JSON_WITH_NO_DOSAGE_INSTRUCTION,
             INPUT_JSON_WITH_NO_DISPENSE_REQUEST,
             INPUT_JSON_WITH_ORDER_NO_BASED_ON,
-            INPUT_JSON_WITH_PLAN_STATUS_REASON_STOPPED_NO_DATE,
-            INPUT_JSON_WITH_NO_RECORDER_REFERENCE,
-            INPUT_JSON_WITH_INVALID_RECORDER_REFERENCE_TYPE
+            INPUT_JSON_WITH_PLAN_STATUS_REASON_STOPPED_NO_DATE
         );
     }
 

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-participant.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-no-participant.xml
@@ -1,0 +1,46 @@
+<component typeCode="COMP">
+    <MedicationStatement classCode="SBADM" moodCode="ORD">
+        <id root="394559384658936"/>
+        <statusCode code="ACTIVE"/>
+        <effectiveTime>
+            <low value="20171110000000"/><high value="20180815000000"/>
+        </effectiveTime>
+        <availabilityTime value="20171110000000"/>
+        <consumable typeCode="CSM">
+            <manufacturedProduct classCode="MANU">
+                <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
+                    <code code="430127000" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Oral Form Oxycodone (product)">
+                    </code>
+                </manufacturedMaterial>
+            </manufacturedProduct>
+        </consumable>
+        <component typeCode="COMP">
+            <ehrSupplyPrescribe>
+                <id root="394559384658936"/>
+                <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                <statusCode code="ACTIVE"/>
+                <availabilityTime value="20171110000000"/>
+                <quantity value="1" unit="1">
+                    <translation value="1">
+                        <originalText>Unk UoM</originalText>
+                    </translation>
+                </quantity>
+                <inFulfillmentOf typeCode="FLFS">
+                    <priorMedicationRef moodCode="INT">
+                        <id root="394559384658936"/>
+                    </priorMedicationRef>
+                </inFulfillmentOf>
+                <pertinentInformation typeCode="PERT">
+                    <pertinentSupplyAnnotation>
+                        <text>Patient Instruction: Take in morning</text>
+                    </pertinentSupplyAnnotation>
+                </pertinentInformation>
+            </ehrSupplyPrescribe>
+        </component>
+        <pertinentInformation typeCode="PERT">
+            <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                <text>1 tablet once a day</text>
+            </pertinentMedicationDosage>
+        </pertinentInformation>
+    </MedicationStatement>
+</component>


### PR DESCRIPTION
## Why

Having done some testing with other GP2GP implementations we've identified that other systems will accept this and optionally generate a fake placeholder Dr within their system when ingesting the record.

While the GP Connect spec insists that a MedicationRequest has a recorder, it is preferable to send the GP2GP extract than fail the transfer completely.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
