### PR TITLE
Improve realism of Observation (Filing comment) tests

### DIFF
--- a/service/src/test/resources/ehr/request/fhir/input/fhir-bundle-observations-after-diagnostic-report.json
+++ b/service/src/test/resources/ehr/request/fhir/input/fhir-bundle-observations-after-diagnostic-report.json
@@ -292,9 +292,6 @@
                 "subject": {
                     "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
                 },
-                "specimen": {
-                    "reference": "Specimen/7E5D5E50-D1CE-41FE-B30D-45D287174031-SPEC-0"
-                },
                 "effectivePeriod": {
                     "start": "2010-01-13",
                     "end": "2010-01-15"

--- a/service/src/test/resources/ehr/request/fhir/input/fhir-bundle-observations-before-diagnostic-report.json
+++ b/service/src/test/resources/ehr/request/fhir/input/fhir-bundle-observations-before-diagnostic-report.json
@@ -36,9 +36,6 @@
                 "subject": {
                     "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
                 },
-                "specimen": {
-                    "reference": "Specimen/7E5D5E50-D1CE-41FE-B30D-45D287174031-SPEC-0"
-                },
                 "effectivePeriod": {
                     "start": "2010-01-13",
                     "end": "2010-01-15"

--- a/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-observations-inside-report.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-observations-inside-report.xml
@@ -149,28 +149,6 @@ Received Date: 2003-01-09 13:54
         <statusCode code="COMPLETE"/>
         <availabilityTime value="20030221115000"/>
     </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="test-id-3"/>
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <low value="20100113"/><high value="20100115"/>
-        </effectiveTime>
-        <availabilityTime value="20100113"/>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="test-id-3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
-CommentDate:20100113
-
-This is some random free text</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20100113"/>
-    </NarrativeStatement>
-</component>
-    </CompoundStatement>
 </component><component typeCode="COMP" contextConductionInd="true">
     <ObservationStatement classCode="OBS" moodCode="EVN">
         <id root="test-id-3"/>


### PR DESCRIPTION
## Why

These test resources aren't valid GP Connect filing comments because the "specimen" field is not a valid field for a filing comment.

The side effect of having the specimen field populated twice is that the expected XML was generating two NarrativeStatements with the text "This is some random free text".

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
