### PR TITLE
Use common DiagnosticReport.isFilingComment in ObservationMapper

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
@@ -1,7 +1,6 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper.diagnosticreport;
 
 import static uk.nhs.adaptors.gp2gp.ehr.mapper.diagnosticreport.DiagnosticReportMapper.DUMMY_OBSERVATION_ID_PREFIX;
-import static uk.nhs.adaptors.gp2gp.ehr.utils.CodeableConceptMappingUtils.hasCode;
 
 import java.util.List;
 import java.util.Objects;
@@ -73,8 +72,6 @@ public class ObservationMapper {
 
     private static final String RANGE_LOW_PREFIX = "Low: ";
     private static final String RANGE_HIGH_PREFIX = "High: ";
-
-    private static final String COMMENT_NOTE_CODE = "37331000000100";
 
     private static final String HL7_UNKNOWN_VALUE = "UNK";
     private static final String HAS_MEMBER_TYPE = "HASMEMBER";
@@ -364,7 +361,7 @@ public class ObservationMapper {
     }
 
     private CommentType prepareCommentType(Observation observation) {
-        return hasCode(observation.getCode(), List.of(COMMENT_NOTE_CODE))
+        return DiagnosticReportMapper.isFilingComment(observation)
             ? CommentType.USER_COMMENT : CommentType.AGGREGATE_COMMENT_SET;
     }
 
@@ -483,7 +480,7 @@ public class ObservationMapper {
     }
 
     private boolean observationHasNonCommentNoteCode(Observation observation) {
-        return observation.hasCode() && !hasCode(observation.getCode(), List.of(COMMENT_NOTE_CODE));
+        return observation.hasCode() && !DiagnosticReportMapper.isFilingComment(observation);
     }
 
     private String prepareCodeElement(Observation observation) {
@@ -546,7 +543,7 @@ public class ObservationMapper {
     }
 
     private boolean hasValidComment(Observation observation) {
-        return observation.hasComment() && hasCode(observation.getCode(), List.of(COMMENT_NOTE_CODE));
+        return observation.hasComment() && DiagnosticReportMapper.isFilingComment(observation);
     }
 
     private MultiStatementObservationHolder createHolder(Observation observationAssociatedWithSpecimen) {


### PR DESCRIPTION
## Why

This method has a clear name describing what it does, and is documented.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
