### PR TITLE
Improve exception messages when mapping MedicationRequest `AvailabilityTime` and `EffectiveTime` fields

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
@@ -137,10 +137,8 @@ public final class StatementTimeMappingUtils {
             }
             return String.format(EFFECTIVE_TIME_LOW_TEMPLATE, toHl7Format(startElement));
         }
-        throw new EhrMapperException("""
-            Could not map EffectiveTime when mapping MedicationRequest resource with id: {%s} %n\
-            Resource must contain a dispense request with a validityPeriod which has a start element."""
-            .formatted(medicationRequest.getId())
+        throw new EhrMapperException(
+            "MedicationRequest/{%s} must contain a dispenseRequest.validityPeriod.start".formatted(medicationRequest.getId())
         );
     }
 
@@ -150,10 +148,8 @@ public final class StatementTimeMappingUtils {
             return String.format(AVAILABILITY_TIME_VALUE_TEMPLATE, toHl7Format(
                 medicationRequest.getDispenseRequest().getValidityPeriod().getStartElement()));
         }
-        throw new EhrMapperException("""
-            Could not map AvailabilityTime when mapping MedicationRequest resource with id: {%s} %n\
-            Resource must contain a dispense request with a validityPeriod which has a start element."""
-            .formatted(medicationRequest.getId())
+        throw new EhrMapperException(
+            "MedicationRequest/{%s} must contain a dispenseRequest.validityPeriod.start".formatted(medicationRequest.getId())
         );
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
@@ -137,7 +137,11 @@ public final class StatementTimeMappingUtils {
             }
             return String.format(EFFECTIVE_TIME_LOW_TEMPLATE, toHl7Format(startElement));
         }
-        throw new EhrMapperException("Could not map Effective Time for Medication Request");
+        throw new EhrMapperException("""
+            Could not map EffectiveTime when mapping MedicationRequest resource with id: {%s} \n
+            Resource must contain a dispense request with a validityPeriod which has a start element."""
+            .formatted(medicationRequest.getId())
+        );
     }
 
     public static String prepareAvailabilityTimeForMedicationRequest(MedicationRequest medicationRequest) {
@@ -146,7 +150,11 @@ public final class StatementTimeMappingUtils {
             return String.format(AVAILABILITY_TIME_VALUE_TEMPLATE, toHl7Format(
                 medicationRequest.getDispenseRequest().getValidityPeriod().getStartElement()));
         }
-        throw new EhrMapperException("Could not map Availability Time for Medication Request");
+        throw new EhrMapperException("""
+            Could not map AvailabilityTime when mapping MedicationRequest resource with id: {%s} \n
+            Resource must contain a dispense request with a validityPeriod which has a start element."""
+            .formatted(medicationRequest.getId())
+        );
     }
 
     public static String prepareEffectiveTimeForEhrFolder(EhrFolderEffectiveTime effectiveTime) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtils.java
@@ -138,7 +138,7 @@ public final class StatementTimeMappingUtils {
             return String.format(EFFECTIVE_TIME_LOW_TEMPLATE, toHl7Format(startElement));
         }
         throw new EhrMapperException("""
-            Could not map EffectiveTime when mapping MedicationRequest resource with id: {%s} \n
+            Could not map EffectiveTime when mapping MedicationRequest resource with id: {%s} %n\
             Resource must contain a dispense request with a validityPeriod which has a start element."""
             .formatted(medicationRequest.getId())
         );
@@ -151,7 +151,7 @@ public final class StatementTimeMappingUtils {
                 medicationRequest.getDispenseRequest().getValidityPeriod().getStartElement()));
         }
         throw new EhrMapperException("""
-            Could not map AvailabilityTime when mapping MedicationRequest resource with id: {%s} \n
+            Could not map AvailabilityTime when mapping MedicationRequest resource with id: {%s} %n\
             Resource must contain a dispense request with a validityPeriod which has a start element."""
             .formatted(medicationRequest.getId())
         );

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtilsTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/utils/StatementTimeMappingUtilsTest.java
@@ -1,0 +1,120 @@
+package uk.nhs.adaptors.gp2gp.ehr.utils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.hl7.fhir.dstu3.model.DateTimeType;
+import org.hl7.fhir.dstu3.model.MedicationRequest;
+
+import org.hl7.fhir.dstu3.model.Period;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
+
+public class StatementTimeMappingUtilsTest {
+
+    private static final String MEDICATION_REQUEST_ID = "00000000-0000-4000-8000-000000000001";
+    private MedicationRequest medicationRequest;
+
+    @BeforeEach
+    void beforeEach() {
+        medicationRequest = new MedicationRequest();
+        medicationRequest.setId(MEDICATION_REQUEST_ID);
+    }
+
+    @Test
+    void When_PrepareEffectiveTimeForMedicationRequestWithoutEffectivePeriod_Expect_EhrMapperExceptionContainingIdIsThrown() {
+        medicationRequest.setDispenseRequest(new MedicationRequest.MedicationRequestDispenseRequestComponent());
+
+        assertThatEhrMapperExceptionWithIdThrown(
+            () -> StatementTimeMappingUtils.prepareEffectiveTimeForMedicationRequest(medicationRequest)
+        );
+    }
+
+    @Test
+    void When_PrepareEffectiveTimeForMedicationRequestWithEffectivePeriodWithoutStart_Expect_EhrMapperExceptionContainingIdIsThrown() {
+        medicationRequest.setDispenseRequest(
+            new MedicationRequest.MedicationRequestDispenseRequestComponent()
+                .setValidityPeriod(new Period())
+        );
+
+        assertThatEhrMapperExceptionWithIdThrown(
+            () -> StatementTimeMappingUtils.prepareEffectiveTimeForMedicationRequest(medicationRequest)
+        );
+    }
+
+    @Test
+    void When_PrepareEffectiveTimeForMedicationRequestWithEffectivePeriodWithStartOnly_Expect_LowXmlElementProduced() {
+        medicationRequest.setDispenseRequest(
+            new MedicationRequest.MedicationRequestDispenseRequestComponent()
+                .setValidityPeriod(new Period()
+                    .setStartElement(new DateTimeType("2024-01-01"))
+                )
+        );
+
+        var effectiveTimeXML = StatementTimeMappingUtils.prepareEffectiveTimeForMedicationRequest(medicationRequest);
+
+        assertThat(effectiveTimeXML)
+            .isEqualTo("<low value=\"20240101\"/>");
+    }
+
+    @Test
+    void When_PrepareEffectiveTimeForMedicationRequestWithEffectivePeriodWithStartAndEnd_Expect_LowAndHighXmlElementsProduced() {
+        medicationRequest.setDispenseRequest(
+            new MedicationRequest.MedicationRequestDispenseRequestComponent()
+                .setValidityPeriod(new Period()
+                    .setStartElement(new DateTimeType("2024-01-01"))
+                    .setEndElement(new DateTimeType("2024-02-02"))
+                )
+        );
+
+        var effectiveTimeXML = StatementTimeMappingUtils.prepareEffectiveTimeForMedicationRequest(medicationRequest);
+
+        assertThat(effectiveTimeXML)
+            .isEqualTo("<low value=\"20240101\"/><high value=\"20240202\"/>");
+    }
+
+    @Test
+    void When_PrepareAvailabilityTimeForMedicationRequestWithoutEffectivePeriod_Expect_EhrMapperExceptionContainingIdIsThrown() {
+        medicationRequest.setDispenseRequest(new MedicationRequest.MedicationRequestDispenseRequestComponent());
+
+        assertThatEhrMapperExceptionWithIdThrown(
+            () -> StatementTimeMappingUtils.prepareAvailabilityTimeForMedicationRequest(medicationRequest)
+        );
+    }
+
+    @Test
+    void When_PrepareAvailabilityTimeForMedicationRequestWithEffectivePeriodWithoutStart_Expect_EhrMapperExceptionContainingIdIsThrown() {
+        medicationRequest.setDispenseRequest(
+            new MedicationRequest.MedicationRequestDispenseRequestComponent()
+                .setValidityPeriod(new Period())
+        );
+
+        assertThatEhrMapperExceptionWithIdThrown(
+            () -> StatementTimeMappingUtils.prepareAvailabilityTimeForMedicationRequest(medicationRequest)
+        );
+    }
+
+    @Test
+    void When_PrepareAvailabilityTimeForMedicationRequestWithEffectivePeriodWithStart_Expect_AvailabilityTimeXmlElementProduced() {
+        medicationRequest.setDispenseRequest(
+            new MedicationRequest.MedicationRequestDispenseRequestComponent()
+                .setValidityPeriod(new Period()
+                    .setStartElement(new DateTimeType("2024-01-01"))
+                )
+        );
+
+        var effectiveTimeXML = StatementTimeMappingUtils.prepareAvailabilityTimeForMedicationRequest(medicationRequest);
+
+        assertThat(effectiveTimeXML)
+            .isEqualTo("<availabilityTime value=\"20240101\"/>");
+    }
+
+
+    private void assertThatEhrMapperExceptionWithIdThrown(ThrowableAssert.ThrowingCallable callable) {
+        assertThatThrownBy(callable)
+            .isInstanceOf(EhrMapperException.class)
+            .hasMessageContaining(MEDICATION_REQUEST_ID);
+    }
+}


### PR DESCRIPTION
## What

* Improve exception message detailing the reason for the failure and the ID of the resource causing the exception. 
* Add unit tests for the `prepareAvailabilityTimeForMedicationRequest` and `prepareEffectiveTimeForMedicationRequest` methods as none previously existed.

## Why

During testing it was difficult to ascertain which resource had caused the exception, or the reasoning behind the failure.  This should make it easier to find and identify the cause of the issue.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x ] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [-] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
