### PR TITLE
NIAD-3218: Fix malformed ehrSupplyDiscontinue / pertinentInformation / pertinentSupplyAnnotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When mapping `Immunizations` which contain a `NOPAT` `meta.security` tag, the resultant XML for that resource
   will contain a `NOPAT` `confidentialityCode` element.
 
+### Fixed
+
+* Fix a malformed XML GP2GP message created when mapping a `MedicationRequest` with `intent` of `plan` and is stopped,
+  but no free text reason for the discontinuation was provided.  
+
 ## [2.1.2] - 2014-10-21
 
 ### Fixed

--- a/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
@@ -60,8 +60,8 @@
                     </priorMedicationRef>
                 </reversalOf>
                 <pertinentInformation typeCode="PERT">
-                    <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
-                        {{#ehrSupplyDiscontinueReasonText}}<text>{{{ehrSupplyDiscontinueReasonText}}}</text>{{/ehrSupplyDiscontinueReasonText}}{{^ehrSupplyDiscontinueReasonText}}<code nullFlavor="UNK"><text>Stopped</text></code>{{/ehrSupplyDiscontinueReasonText}}
+                    <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN"{{^ehrSupplyDiscontinueReasonText}} nullFlavor="UNK"{{/ehrSupplyDiscontinueReasonText}}>
+                        {{#ehrSupplyDiscontinueReasonText}}<text>{{{ehrSupplyDiscontinueReasonText}}}</text>{{/ehrSupplyDiscontinueReasonText}}{{^ehrSupplyDiscontinueReasonText}}<text>Stopped</text>{{/ehrSupplyDiscontinueReasonText}}
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyDiscontinue>

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-default-status-reason-code.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-authorise-default-status-reason-code.xml
@@ -48,8 +48,8 @@
                     </priorMedicationRef>
                 </reversalOf>
                 <pertinentInformation typeCode="PERT">
-                    <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
-                        <code nullFlavor="UNK"><text>Stopped</text></code>
+                    <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN" nullFlavor="UNK">
+                        <text>Stopped</text>
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyDiscontinue>

--- a/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP3.json
+++ b/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP3.json
@@ -1151,12 +1151,6 @@
                         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatusReason-1",
                         "extension": [
                             {
-                                "url": "statusReason",
-                                "valueCodeableConcept": {
-                                    "text": "Expired"
-                                }
-                            },
-                            {
                                 "url": "statusChangeDate",
                                 "valueDateTime": "2019-05-10T02:00:09.943+01:00"
                             }


### PR DESCRIPTION
## What

When a MedicationRequest didn't have reason text to provide, we were providing an invalid code element within the pertinentSupplyInformation.

This is invalid according to the spec.

Instead, move the nullFlavor annotation to the pertinentSupplyAnnotation where it is valid.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
