### PR TITLE
NIAD-3227: When mapping `Observation` valueQuantities, any input from the GP Connect Bundle should be escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+* When mapping a `valueQuantity` contained in an `Observation`, the produced XML `<value>` element now correctly escapes
+  any contained XML characters.
+
 ## Added
 
 * When mapping a `DocumentReference` which contains a `NOPAT` `meta.security` or `NOPAT` `securityLabel` tag the resultant XML for that resource

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapper.java
@@ -1,6 +1,7 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.hl7.fhir.dstu3.model.BooleanType;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Quantity;
@@ -52,12 +53,15 @@ public final class ObservationValueQuantityMapper {
     }
 
     private static String getPhysicalQuantityXml(Quantity valueQuantity) {
+        var escapedCode = StringEscapeUtils.escapeXml11(valueQuantity.getCode());
+        var escapedUnit = StringEscapeUtils.escapeXml11(valueQuantity.getUnit());
+
         if (UNITS_OF_MEASURE_SYSTEM.equals(valueQuantity.getSystem()) && valueQuantity.hasCode()) {
             return """
                 <value xsi:type="PQ" value="%s" unit="%s" />"""
                 .formatted(
                     valueQuantity.getValue(),
-                    valueQuantity.getCode()
+                    escapedCode
                 );
         }
         if (hasValidSystem(valueQuantity) && valueQuantity.hasCode() && valueQuantity.hasUnit()) {
@@ -68,9 +72,9 @@ public final class ObservationValueQuantityMapper {
                 .formatted(
                     valueQuantity.getValue(),
                     valueQuantity.getValue(),
-                    valueQuantity.getCode(),
+                    escapedCode,
                     getSystemWithoutPrefix(valueQuantity.getSystem()),
-                    valueQuantity.getUnit()
+                    escapedUnit
                 );
         }
         if (hasValidSystem(valueQuantity) && valueQuantity.hasCode()) {
@@ -81,7 +85,7 @@ public final class ObservationValueQuantityMapper {
                 .formatted(
                     valueQuantity.getValue(),
                     valueQuantity.getValue(),
-                    valueQuantity.getCode(),
+                    escapedCode,
                     getSystemWithoutPrefix(valueQuantity.getSystem())
                 );
         }
@@ -95,7 +99,7 @@ public final class ObservationValueQuantityMapper {
                 .formatted(
                     valueQuantity.getValue(),
                     valueQuantity.getValue(),
-                    valueQuantity.getUnit()
+                    escapedUnit
                 );
         }
 
@@ -105,6 +109,9 @@ public final class ObservationValueQuantityMapper {
     }
 
     private static String getPhysicalQuantityIntervalXml(Quantity valueQuantity) {
+        var escapedCode = StringEscapeUtils.escapeXml11(valueQuantity.getCode());
+        var escapedUnit = StringEscapeUtils.escapeXml11(valueQuantity.getUnit());
+
         if (UNITS_OF_MEASURE_SYSTEM.equals(valueQuantity.getSystem()) && valueQuantity.hasCode()) {
             return """
                 <value xsi:type="IVL_PQ">%n\
@@ -113,7 +120,7 @@ public final class ObservationValueQuantityMapper {
                 .formatted(
                     getHighOrLow(valueQuantity),
                     valueQuantity.getValue(),
-                    valueQuantity.getCode(),
+                    escapedCode,
                     isInclusive(valueQuantity)
                 );
         }
@@ -129,9 +136,9 @@ public final class ObservationValueQuantityMapper {
                     valueQuantity.getValue(),
                     isInclusive(valueQuantity),
                     valueQuantity.getValue(),
-                    valueQuantity.getCode(),
+                    escapedCode,
                     getSystemWithoutPrefix(valueQuantity.getSystem()),
-                    valueQuantity.getUnit(),
+                    escapedUnit,
                     getHighOrLow(valueQuantity)
             );
         }
@@ -147,7 +154,7 @@ public final class ObservationValueQuantityMapper {
                     valueQuantity.getValue(),
                     isInclusive(valueQuantity),
                     valueQuantity.getValue(),
-                    valueQuantity.getCode(),
+                    escapedCode,
                     getSystemWithoutPrefix(valueQuantity.getSystem()),
                     getHighOrLow(valueQuantity)
                 );
@@ -166,7 +173,7 @@ public final class ObservationValueQuantityMapper {
                     valueQuantity.getValue(),
                     isInclusive(valueQuantity),
                     valueQuantity.getValue(),
-                    valueQuantity.getUnit(),
+                    escapedUnit,
                     getHighOrLow(valueQuantity)
                 );
         }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationValueQuantityMapperTest.java
@@ -38,6 +38,7 @@ public class ObservationValueQuantityMapperTest {
     public static final String SYSTEM_UUID = "e1423232-5d4f-472f-8c55-271de1d6f98d";
     public static final String SYSTEM_UUID_WITH_PREFIX = "urn:uuid:e1423232-5d4f-472f-8c55-271de1d6f98d";
     public static final String INVALID_SYSTEM = "not-a-valid-system";
+    public static final String STRING_WITH_XML_TO_BE_ESCAPED = "\" ' & < >";
 
     @Test
     public void When_MappingQuantityWithUncertaintyExtension_Expect_XmlContainsUncertaintyCode() {
@@ -518,6 +519,39 @@ public class ObservationValueQuantityMapperTest {
                 <low value="37.1" unit="1" inclusive="false" />
             </value>""";
 
+        var mappedQuantity = ObservationValueQuantityMapper.processQuantity(quantity);
+
+        assertThat(mappedQuantity).isEqualTo(expectedXml);
+    }
+
+    @Test
+    public void When_MappingWithXmlCharactersInCode_Expect_XmlCharactersAreEscaped() {
+        var quantity = new Quantity()
+            .setSystem(UOM_SYSTEM)
+            .setValue(VALUE_37_1)
+            .setCode(STRING_WITH_XML_TO_BE_ESCAPED);
+
+        var expectedXml = """
+            <value xsi:type="PQ" value="37.1" unit="&quot; &apos; &amp; &lt; &gt;" />""";
+
+        var mappedQuantity = ObservationValueQuantityMapper.processQuantity(quantity);
+
+        assertThat(mappedQuantity).isEqualTo(expectedXml);
+    }
+
+    @Test
+    public void When_MappingWithXmlCharactersInUnit_Expect_XmlCharactersAreEscaped() {
+        var quantity = new Quantity()
+            .setSystem(UOM_SYSTEM)
+            .setValue(VALUE_37_1)
+            .setUnit(STRING_WITH_XML_TO_BE_ESCAPED);
+
+        var expectedXml = """
+            <value xsi:type="PQ" value="37.1" unit="1">
+                <translation value="37.1">
+                    <originalText>&quot; &apos; &amp; &lt; &gt;</originalText>
+                </translation>
+            </value>""";
         var mappedQuantity = ObservationValueQuantityMapper.processQuantity(quantity);
 
         assertThat(mappedQuantity).isEqualTo(expectedXml);


### PR DESCRIPTION
## What

Add functionality to XML escape the `code` and `unit` when generating the XML string. `value` does not need to be escaped as it is a `BigDecimal` type. Add unit tests to test above functionality.

## Why

To avoid the possibility of XML Injection, and to ensure that any generated XML is formatted correctly, all input from the GP Connect Bundle should be XML escaped when mapping `Observation` valueQuantities.

For example, if the input bundle contains the following valueQuantity:

```json
"valueQuantity": {
    "value": 186,
    "unit": "<None>",
    "system": "http://unitsofmeasure.org"
}
```
Then the resultant `<value>` element should contain the XML Escaped value for `unit`:

```xml
<value xsi:type="PQ" value="186" unit="1">
    <translation value="186">
        <originalText>&lt;None&gt;</originalText>
    </translation>
</value>
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
