### PR TITLE
NIAD-3222: GP2GP adaptor generates an empty `CompoundStatement/code` which fails the transfer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+* When mapping an `Observation` related to a diagnostic report which does not contain a `code` element, the adaptor will
+  now throw an error reporting that an observation requires a code element and provide the affected resource ID.
 * When mapping a `valueQuantity` contained in an `Observation`, the produced XML `<value>` element now correctly escapes
   any contained XML characters.
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapper.java
@@ -488,7 +488,7 @@ public class ObservationMapper {
             return codeableConceptCdMapper.mapCodeableConceptToCd(observation.getCode());
         }
 
-        return StringUtils.EMPTY;
+        throw new EhrMapperException("%s must contain a code element.".formatted(observation.getId()));
     }
 
     private CompoundStatementClassCode prepareClassCode(List<MultiStatementObservationHolder> derivedObservations) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/ObservationMapperTest.java
@@ -21,6 +21,7 @@ import org.mockito.stubbing.Answer;
 import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
+import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.AgentDirectory;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.CodeableConceptCdMapper;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.IdMapper;
@@ -36,6 +37,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -218,8 +220,19 @@ class ObservationMapperTest {
 
         assertAll(
             () -> assertThatXml(actualXml).containsXPath(COMPOUND_STATEMENT_CONFIDENTIALITY_CODE_XPATH),
-            () -> assertThat(metaWithNopat).hasSize(1)
+            () -> assertThat(metaWithNopat).hasSize(2)
         );
+    }
+
+    @Test
+    void When_MappingTestGroupHeader_WithoutCode_Expect_ExceptionThrownContainingId() {
+        final Observation observation = getObservationResourceFromJson(OBSERVATION_TEST_GROUP_HEADER_JSON);
+        observation.setCode(null);
+
+        assertThatExceptionOfType(EhrMapperException.class)
+            .isThrownBy(() -> observationMapper.mapObservationToCompoundStatement(observation))
+            .withMessageContaining(observation.getId());
+
     }
 
     @Test

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_test_group_header.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/observation/observation_test_group_header.json
@@ -6,6 +6,15 @@
       "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
     ]
   },
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "242247008",
+        "display": "Collision of spacecraft with meteorite"
+      }
+    ]
+  },
   "identifier": [
     {
       "system": "https://EMISWeb/A82038",


### PR DESCRIPTION
## What

* Replace String.Empty when preparing the code element mapping ObservationMapper so that an EhrMapperException is thrown containing the resource identifier. 
* Add test to ensure this exception is found and contains the resource ID.
* Update NOPAT test and associated resource file which previously did not contain a code element 
* Update CHANGELOG.md

## Why

Within the `diagnosticreport.ObservationMapper::prepareCodeElement` there is the possibility of generating an EMPTY code element:

```java
private String prepareCodeElement(Observation observation) {
    if (observation.hasCode()) {
        return codeableConceptCdMapper.mapCodeableConceptToCd(observation.getCode());
    }

    return StringUtils.EMPTY;
}
```

This results in a `CompoundStatement` without a code element, which is invalid, and will cause the requesting system to reject the EHRExtract.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
