### PR TITLE
Configure Gradle to automate the deletion of older summaries on Github Pull Requests

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -162,7 +162,6 @@ pitest {
 
 pitestGithub {
 	deleteOldSummaries = true
-
 }
 
 bootJar {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
 	pitest 'com.arcmutate:base:1.3.1'
-	pitest 'com.arcmutate:pitest-git-plugin:1.3.3'
+	pitest 'com.arcmutate:pitest-github-plugin:1.3.3'
 }
 
 test {
@@ -158,6 +158,10 @@ pitest {
 	mutators = ['STRONGER', 'EXTENDED_ALL']
 
 	threads = project.getGradle().getStartParameter().getMaxWorkerCount()
+}
+
+pitestGithub {
+	deleteOldSummaries = true
 }
 
 bootJar {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -162,6 +162,7 @@ pitest {
 
 pitestGithub {
 	deleteOldSummaries = true
+
 }
 
 bootJar {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
 	pitest 'com.arcmutate:base:1.3.1'
-	pitest 'com.arcmutate:pitest-github-plugin:1.3.3'
+	pitest 'com.arcmutate:pitest-git-plugin:1.3.3'
 }
 
 test {


### PR DESCRIPTION
## What

Configure Gradle to automate the deletion of older summaries on Github Pull Requests

## Why

When committing to a branch which has an open PR, the mutation testing will rerun and generate a new summary, leaving the old summary in place, which is no longer relevant.  This then had to be manually deleted or remain as clutter.  This change configures the plugin to delete old summaries.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
