### PR TITLE
Configure Gradle to automate the deletion of older summaries on Github Pull Requests

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -160,6 +160,10 @@ pitest {
 	threads = project.getGradle().getStartParameter().getMaxWorkerCount()
 }
 
+pitestGithub {
+	deleteOldSummaries = true
+}
+
 bootJar {
 	exclude("**/TransformJsonToXml*")
 }


### PR DESCRIPTION
## What

Configure Gradle to automate the deletion of older summaries on Github Pull Requests

## Why

When committing to a branch which has an open PR, the mutation testing will rerun and generate a new summary, leaving the old summary in place, which is no longer relevant.  This then had to be manually deleted or remain as clutter.  This change configures the plugin to delete old summaries.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes