### PR TITLE
NIAD-3234: introduction of a factory method to create instances of GetGpcStructuredTaskDefinition class

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/request/EhrExtractRequestHandler.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/request/EhrExtractRequestHandler.java
@@ -97,18 +97,12 @@ public class EhrExtractRequestHandler {
     }
 
     private void createGetGpcStructuredTask(EhrExtractStatus ehrExtractStatus) {
-        var getGpcStructuredTaskDefinition = GetGpcStructuredTaskDefinition.builder()
-            .nhsNumber(ehrExtractStatus.getEhrRequest().getNhsNumber())
-            .taskId(randomIdGeneratorService.createNewId())
-            .conversationId(ehrExtractStatus.getConversationId())
-            .requestId(ehrExtractStatus.getEhrRequest().getRequestId())
-            .toAsid(ehrExtractStatus.getEhrRequest().getToAsid())
-            .fromAsid(ehrExtractStatus.getEhrRequest().getFromAsid())
-            .toOdsCode(ehrExtractStatus.getEhrRequest().getToOdsCode())
-            .fromOdsCode(ehrExtractStatus.getEhrRequest().getFromOdsCode())
-            .build();
+        var getGpcStructuredTaskDefinition = GetGpcStructuredTaskDefinition.getGetGpcStructuredTaskDefinition(randomIdGeneratorService,
+                                                                                                              ehrExtractStatus);
         taskDispatcher.createTask(getGpcStructuredTaskDefinition);
     }
+
+
 
     private EhrExtractStatus.EhrRequest prepareMinimalEhrRequest(Document header, Document payload) {
         return EhrExtractStatus.EhrRequest.builder()

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskDefinition.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/GetGpcStructuredTaskDefinition.java
@@ -6,8 +6,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.common.task.TaskDefinition;
 import uk.nhs.adaptors.gp2gp.common.task.TaskType;
+import uk.nhs.adaptors.gp2gp.ehr.model.EhrExtractStatus;
 
 /**
  * Task definition for downloading Structured Record from GCP
@@ -25,5 +27,20 @@ public class GetGpcStructuredTaskDefinition extends TaskDefinition {
     @Override
     public TaskType getTaskType() {
         return GET_GPC_STRUCTURED;
+    }
+
+    public static GetGpcStructuredTaskDefinition getGetGpcStructuredTaskDefinition(RandomIdGeneratorService randomIdGeneratorService,
+                                                                                   EhrExtractStatus ehrExtractStatus) {
+        var getGpcStructuredTaskDefinition = GetGpcStructuredTaskDefinition.builder()
+            .nhsNumber(ehrExtractStatus.getEhrRequest().getNhsNumber())
+            .taskId(randomIdGeneratorService.createNewId())
+            .conversationId(ehrExtractStatus.getConversationId())
+            .requestId(ehrExtractStatus.getEhrRequest().getRequestId())
+            .toAsid(ehrExtractStatus.getEhrRequest().getToAsid())
+            .fromAsid(ehrExtractStatus.getEhrRequest().getFromAsid())
+            .toOdsCode(ehrExtractStatus.getEhrRequest().getToOdsCode())
+            .fromOdsCode(ehrExtractStatus.getEhrRequest().getFromOdsCode())
+            .build();
+        return getGpcStructuredTaskDefinition;
     }
 }


### PR DESCRIPTION
 ## What

introduction of a factory method to create instances of GetGpcStructuredTaskDefinition class

## Why

Moving a functionality of GetGpcStructuredTaskDefinition instances creation into a better place
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
