### PR TITLE
Add test to characterise existing behaviour of DignosticReportMapper

### DIFF
--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapperTest.java
@@ -76,6 +76,7 @@ class DiagnosticReportMapperTest {
     private static final String INPUT_JSON_MULTIPLE_CODED_DIAGNOSIS = "diagnostic-report-with-multiple-coded-diagnosis.json";
     private static final String INPUT_JSON_EXTENSION_ID = "diagnostic-report-with-extension-id.json";
     private static final String INPUT_JSON_URN_OID_EXTENSION_ID = "diagnostic-report-with-urn-oid-extension-id.json";
+    private static final String INPUT_JSON_UNRELATED_TEST_RESULT = "diagnostic-report-with-one-specimen-and-one-unrelated-observation.json";
 
     private static final String OUTPUT_XML_REQUIRED_DATA = "diagnostic-report-with-required-data.xml";
     private static final String OUTPUT_XML_STATUS_NARRATIVE = "diagnostic-report-with-status-narrative.xml";
@@ -87,6 +88,7 @@ class DiagnosticReportMapperTest {
     private static final String OUTPUT_XML_MULTIPLE_CODED_DIAGNOSIS = "diagnostic-report-with-multiple-coded-diagnosis.xml";
     private static final String OUTPUT_XML_EXTENSION_ID = "diagnostic-report-with-extension-id.xml";
     private static final String OUTPUT_XML_MULTIPLE_RESULTS = "diagnostic-report-with-multiple-results.xml";
+    private static final String OUTPUT_XML_UNRELATED_TEST_RESULT = "diagnostic-report-with-one-specimen-and-one-unrelated-observation.xml";
 
     @Mock
     private CodeableConceptCdMapper codeableConceptCdMapper;
@@ -137,7 +139,7 @@ class DiagnosticReportMapperTest {
 
         final String outputMessage = mapper.mapDiagnosticReportToCompoundStatement(diagnosticReport);
 
-        assertThat(removeLineEndings(outputMessage)).isEqualTo(removeLineEndings(expectedOutputMessage.toString()));
+        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutputMessage.toString());
     }
 
     @Test
@@ -301,10 +303,6 @@ class DiagnosticReportMapperTest {
         return FileParsingUtility.parseResourceFromJsonFile(filePath, DiagnosticReport.class);
     }
 
-    private String removeLineEndings(String input) {
-        return input.replace("\n", "").replace("\r", "");
-    }
-
     private static Stream<Arguments> resourceFileParams() {
         return Stream.of(
             Arguments.of(INPUT_JSON_REQUIRED_DATA, OUTPUT_XML_STATUS_NARRATIVE),
@@ -320,7 +318,8 @@ class DiagnosticReportMapperTest {
             Arguments.of(INPUT_JSON_CODED_DIAGNOSIS, OUTPUT_XML_CODED_DIAGNOSIS),
             Arguments.of(INPUT_JSON_MULTIPLE_CODED_DIAGNOSIS, OUTPUT_XML_MULTIPLE_CODED_DIAGNOSIS),
             Arguments.of(INPUT_JSON_EXTENSION_ID, OUTPUT_XML_EXTENSION_ID),
-            Arguments.of(INPUT_JSON_URN_OID_EXTENSION_ID, OUTPUT_XML_EXTENSION_ID)
+            Arguments.of(INPUT_JSON_URN_OID_EXTENSION_ID, OUTPUT_XML_EXTENSION_ID),
+            Arguments.of(INPUT_JSON_UNRELATED_TEST_RESULT, OUTPUT_XML_UNRELATED_TEST_RESULT)
         );
     }
 

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-one-specimen-and-one-unrelated-observation.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-one-specimen-and-one-unrelated-observation.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "DiagnosticReport",
+  "id": "96B93E28-293D-46E7-B4C2-D477EEBF7098",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+    ]
+  },
+  "identifier": [
+    {
+      "system": "https://EMISWeb/A82038",
+      "value": "96B93E28-293D-46E7-B4C2-D477EEBF7098"
+    }
+  ],
+  "status": "unknown",
+  "category": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v2/0074",
+        "code": "PAT",
+        "display": "Pathology (gross & histopath, not surgical)"
+      }
+    ]
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "721981007",
+        "display": "Diagnostic studies report"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+  },
+  "issued": "2010-02-25T15:41:00+00:00",
+  "result": [
+    {
+      "reference": "Observation/TestResult-WithoutSpecimenReference"
+    }
+  ],
+  "specimen":[
+    {
+      "reference":"Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0"
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-one-specimen-and-one-unrelated-observation.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-one-specimen-and-one-unrelated-observation.xml
@@ -1,0 +1,25 @@
+<component typeCode="COMP">
+    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+        <id root="II-for-DiagnosticReport-DiagnosticReport/96B93E28-293D-46E7-B4C2-D477EEBF7098"/>
+        <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="laboratory reporting">
+            <originalText>Filed Report</originalText>
+        </code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center nullFlavor="NI"/>
+        </effectiveTime>
+        <availabilityTime value="20100225154100"/>
+            <component typeCode="COMP" contextConductionInd="true">
+    <NarrativeStatement classCode="OBS" moodCode="EVN">
+        <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+        <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
+CommentDate:20100225154100
+
+Status: unknown</text>
+        <statusCode code="COMPLETE"/>
+        <availabilityTime value="20100225154100"/>
+    </NarrativeStatement>
+</component>
+        <!-- Mapped Specimen with id: Specimen/96B93E28-293D-46E7-B4C2-D477EEBF7098-SPEC-0 -->
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/fhir_bundle.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/fhir_bundle.json
@@ -374,6 +374,73 @@
         ]
       }
     },
+
+    {
+      "resource":{
+        "resourceType":"Observation",
+        "id":"TestResult-WithoutSpecimenReference",
+        "meta":{
+          "profile":[
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+          ]
+        },
+        "identifier":[
+          {
+            "system":"https://EMISWeb/A82038",
+            "value":"AD373CA7-3940-4249-85A2-D3A22E9F17C7"
+          }
+        ],
+        "status":"unknown",
+        "category":[
+          {
+            "coding":[
+              {
+                "system":"http://hl7.org/fhir/observation-category",
+                "code":"laboratory",
+                "display":"Laboratory"
+              }
+            ]
+          }
+        ],
+        "code":{
+          "coding":[
+            {
+              "system":"http://read.info/readv2",
+              "code":"4483.00",
+              "display":"Serum ACTH",
+              "userSelected":true
+            },
+            {
+              "extension":[
+                {
+                  "url":"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                  "extension":[
+                    {
+                      "url":"descriptionId",
+                      "valueId":"2563401000000119"
+                    }
+                  ]
+                }
+              ],
+              "system":"http://snomed.info/sct",
+              "code":"997201000000100",
+              "display":"Normal levels detected"
+            }
+          ]
+        },
+        "subject":{
+          "reference":"Patient/DAED5527-1985-45D9-993E-C5FF51F36828"
+        },
+        "effectiveDateTime":"2010-02-23",
+        "issued":"2010-02-25T15:41:00+00:00",
+        "performer":[
+          {
+            "reference":"Practitioner/C8FD0E2C-3124-4C72-AC8D-ABEA65537D1B"
+          }
+        ],
+        "comment":"This is a test result without a specimen."
+      }
+    },
     {
       "resource":{
         "resourceType":"Observation",


### PR DESCRIPTION
## What

Existing behaviour of DiagnosticReportMapper only generates a dummy specimen when there aren't any Specimens.

However, we will want to generate a Dummy Specimen if there also exists an Observation without a reference to a Specimen.

## Why

This test characterises the existing behaviour in advance of fixing it.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
