### PR TITLE
Code Quality: Non-constant string concatenation as argument to logging call

### DIFF
--- a/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/service/MockMhsService.java
+++ b/mock-mhs-adaptor/src/main/java/uk/nhs/adaptors/mockmhsservice/service/MockMhsService.java
@@ -75,7 +75,7 @@ public class MockMhsService {
                 EHR_EXTRACT_ID_MAP.put(correlationId, messageId);
                 var inboundMessage = STUB_CONTINUE_REPLY_INBOUND_MESSAGE.replace("%%ConversationId%%", correlationId);
                 inboundProducer.sendToMhsInboundQueue(inboundMessage);
-                LOGGER.info("Placed message on Inbound Queue, conversationId: " + correlationId);
+                LOGGER.info("Placed message on Inbound Queue, conversationId: {}", correlationId);
                 headers.setContentType(MediaType.TEXT_XML);
                 return new ResponseEntity<>(STUB_ACCEPTED_RESPONSE, headers, ACCEPTED);
             } catch (JmsException e) {
@@ -94,7 +94,7 @@ public class MockMhsService {
                 }
 
                 inboundProducer.sendToMhsInboundQueue(inboundMessage);
-                LOGGER.info("Message acknowledgement sent to Inbound Queue, conversationId: " + correlationId);
+                LOGGER.info("Message acknowledgement sent to Inbound Queue, conversationId: {}", correlationId);
                 headers.setContentType(MediaType.TEXT_XML);
                 return new ResponseEntity<>(STUB_ACCEPTED_RESPONSE, headers, ACCEPTED);
             } catch (JmsException e) {


### PR DESCRIPTION
## What

Code Quality fix for non-constant string concatenation when logging in `MockMhsService`


## Why

Non-constant concatenations are evaluated at runtime even when the logging message is not logged; this can negatively impact performance. It is recommended to use a parameterised log message instead, which will not be evaluated when logging is disabled

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
