### PR TITLE
NIAD 3217 - Fix duplicated Test Results

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -87,7 +87,9 @@ public class DiagnosticReportMapper {
                 specimens);
 
         String mappedSpecimens = specimens.stream()
-            .map(specimen -> specimenMapper.mapSpecimenToCompoundStatement(specimen, observationsExcludingFilingComments, diagnosticReport))
+            .map(specimen -> specimenMapper.mapSpecimenToCompoundStatement(specimen,
+                    observationsForSpecimen(specimen, observationsExcludingFilingComments),
+                    diagnosticReport))
             .collect(Collectors.joining());
 
         String reportLevelNarrativeStatements = prepareReportLevelNarrativeStatements(diagnosticReport, observations);
@@ -111,6 +113,13 @@ public class DiagnosticReportMapper {
             DIAGNOSTIC_REPORT_COMPOUND_STATEMENT_TEMPLATE,
             diagnosticReportCompoundStatementTemplateParameters.build()
         );
+    }
+
+    private List<Observation> observationsForSpecimen(Specimen specimen, List<Observation> observations) {
+        return observations.stream()
+                .filter(Observation::hasSpecimen)
+                .filter(observation -> observation.getSpecimen().getReference().equals(specimen.getId()))
+                .collect(Collectors.toList());
     }
 
     private String fetchExtensionId(List<Identifier> identifiers) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/SpecimenMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/SpecimenMapperTest.java
@@ -139,7 +139,7 @@ class SpecimenMapperTest {
         final String actualXml = specimenMapper.mapSpecimenToCompoundStatement(
             specimen, observations, DIAGNOSTIC_REPORT);
 
-        assertThat(actualXml).isEqualTo(expectedXml);
+        assertThat(actualXml).isEqualToIgnoringWhitespace(expectedXml);
     }
 
     @Test

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-no-specimen.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-no-specimen.json
@@ -54,7 +54,7 @@
       "reference": "Observation/FILING-COMMENT-WITH-NO-COMMENT"
     },
     {
-      "reference": "Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"
+      "reference": "Observation/TestResult-WithoutSpecimenReference"
     }
   ]
 }

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-no-specimen.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-no-specimen.xml
@@ -68,8 +68,8 @@
                     </specimenRole>
                 </specimen>
                 <component typeCode="COMP" contextConductionInd="true">
-                    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-                        <id root="II-for-Observation-Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78"/>
+                    <ObservationStatement classCode="OBS" moodCode="EVN">
+                        <id root="II-for-Observation-Observation/TestResult-WithoutSpecimenReference"/>
                         <code nullFlavor="UNK">
                             <originalText>Mocked code</originalText>
                         </code>
@@ -78,46 +78,19 @@
                             <center value="20100223"/>
                         </effectiveTime>
                         <availabilityTime value="20100223"/>
-                        <component typeCode="COMP" contextConductionInd="true">
-                            <ObservationStatement classCode="OBS" moodCode="EVN">
-                                <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
-                                <code nullFlavor="UNK">
-                                    <originalText>Mocked code</originalText>
-                                </code>
-                                <statusCode code="COMPLETE"/>
-                                <effectiveTime>
-                                    <center value="20100223"/>
-                                </effectiveTime>
-                                <availabilityTime value="20100223"/>
-                                <value xsi:type="PQ" value="8.800" unit="1">
-                                    <translation value="8.800">
-                                        <originalText>mmol/L</originalText>
-                                    </translation>
-                                </value>
-                                <referenceRange typeCode="REFV">
-                                    <referenceInterpretationRange classCode="OBS" moodCode="EVN.CRT">
-                                        <value>
-                                            <low value="10.000"/>
-                                            <high value="90.000"/>
-                                        </value>
-                                    </referenceInterpretationRange>
-                                </referenceRange>
+                    </ObservationStatement>
+                </component>
+                <component typeCode="COMP" contextConductionInd="true">
+                    <NarrativeStatement classCode="OBS" moodCode="EVN">
+                        <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                            CommentDate:20100223
 
-                            </ObservationStatement>
-                        </component>
-                        <component typeCode="COMP" contextConductionInd="true">
-                            <NarrativeStatement classCode="OBS" moodCode="EVN">
-                                <id root="II-for-Observation-Observation/6E30A9E3-FF9A-4868-8FCD-7DAC26A16E78-COMM"/>
-                                <text mediaType="text/x-h7uk-pmip">CommentType:USER COMMENT
-                                    CommentDate:20201215151713
-
-                                    (q) - Normal - No Action
-                                </text>
-                                <statusCode code="COMPLETE"/>
-                                <availabilityTime value="20201215151713"/>
-                            </NarrativeStatement>
-                        </component>
-                    </CompoundStatement>
+                            This is a test result without a specimen.
+                        </text>
+                        <statusCode code="COMPLETE"/>
+                        <availabilityTime value="20100223"/>
+                    </NarrativeStatement>
                 </component>
             </CompoundStatement>
         </component>

--- a/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-standalone-observations.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-standalone-observations.xml
@@ -1,293 +1,306 @@
 <EhrExtract classCode="EXTRACT" moodCode="EVN">
-    <id root="test-id-1" />
-    <statusCode code="COMPLETE" />
-    <availabilityTime value="20200101010101" />
+    <id root="test-id-1"/>
+    <statusCode code="COMPLETE"/>
+    <availabilityTime value="20200101010101"/>
     <recordTarget typeCode="RCT">
         <patient classCode="PAT">
-            <id root="2.16.840.1.113883.2.1.4.1" extension="1234567890" />
+            <id root="2.16.840.1.113883.2.1.4.1" extension="1234567890"/>
         </patient>
     </recordTarget>
     <author typeCode="AUT">
-        <time value="20200101010101" />
+        <time value="20200101010101"/>
         <AgentOrgSDS classCode="AGNT">
             <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
-                <id root="1.2.826.0.1285.0.1.10" extension="test-to-ods-code" />
+                <id root="1.2.826.0.1285.0.1.10" extension="test-to-ods-code"/>
             </agentOrganizationSDS>
         </AgentOrgSDS>
     </author>
     <destination typeCode="DST">
         <AgentOrgSDS classCode="AGNT">
             <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
-                <id root="1.2.826.0.1285.0.1.10" extension="test-from-ods-code" />
+                <id root="1.2.826.0.1285.0.1.10" extension="test-from-ods-code"/>
             </agentOrganizationSDS>
         </AgentOrgSDS>
     </destination>
     <component typeCode="COMP">
         <ehrFolder classCode="FOLDER" moodCode="EVN">
-            <id root="test-id-2" />
-            <statusCode code="COMPLETE" />
+            <id root="test-id-2"/>
+            <statusCode code="COMPLETE"/>
             <effectiveTime>
                 <low value="20030221115000"/>
             </effectiveTime>
-            <availabilityTime value="20200101010101" />
+            <availabilityTime value="20200101010101"/>
             <author typeCode="AUT">
-                <time value="20200101010101" />
+                <time value="20200101010101"/>
                 <AgentOrgSDS classCode="AGNT">
                     <agentOrganizationSDS classCode="ORG" determinerCode="INSTANCE">
-                        <id root="1.2.826.0.1285.0.1.10" extension="test-to-ods-code" />
+                        <id root="1.2.826.0.1285.0.1.10" extension="test-to-ods-code"/>
                     </agentOrganizationSDS>
                 </AgentOrgSDS>
             </author>
             <responsibleParty typeCode="RESP">
-    <agentDirectory classCode="AGNT">
-        <part typeCode="PART">
-    <Agent classCode="AGNT">
-        <id root="test-id-3"/>
-        <code nullFlavor="UNK">
-            <originalText>Unknown</originalText>
-        </code>
-        <agentPerson classCode="PSN" determinerCode="INSTANCE">
-            <name>
-                <family>TEMPLE SOWERBY MEDICAL PRACTICE</family>
-            </name>
-        </agentPerson>
-    </Agent>
-</part>
-            <part typeCode="PART">
-    <Agent classCode="AGNT">
-        <id root="test-id-3"/>
-        <code nullFlavor="UNK">
-            <originalText>Unknown</originalText>
-        </code>
-        <agentPerson classCode="PSN" determinerCode="INSTANCE">
-            <name>
-                <prefix>Dr</prefix>
-                <given>David</given>
-                <family>McAvenue</family>
-            </name>
-        </agentPerson>
-    </Agent>
-</part>
-    </agentDirectory>
-</responsibleParty>
-                <component typeCode="COMP">
-    <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-        <id root="test-id-3" />
-        <code code="109341000000100" displayName="GP to GP communication transaction" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-        <statusCode code="COMPLETE" />
-        <effectiveTime>
-            <center value="20030221115000"/>
-        </effectiveTime>
-        <availabilityTime value="20030221115000"/>
-        <author typeCode="AUT" contextControlCode="OP">
-            <time value="20030221115000" />
-            <agentRef classCode="AGNT">
-                <id nullFlavor="UNK" />
-            </agentRef>
-        </author>
-        <Participant2 typeCode="PRF" contextControlCode="OP">
-            <agentRef classCode="AGNT">
-                <id nullFlavor="UNK"/>
-            </agentRef>
-        </Participant2>
-        <component typeCode="COMP">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="test-id-3"/>
-        <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="laboratory reporting">
-            <originalText>Filed Report</originalText>
-        </code>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="NI"/>
-        </effectiveTime>
-        <availabilityTime value="20030221115000"/>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="test-id-3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
-CommentDate:20030221115000
-
-Status: unknown</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20030221115000"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-        <id root="test-id-3"/>
-        <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
-        <statusCode code="COMPLETE"/>
-        <effectiveTime>
-            <center nullFlavor="NI"/>
-        </effectiveTime>
-        <availabilityTime value="20030221115000"/>
-        <specimen typeCode="SPC">
-            <specimenRole classCode="SPEC">
-                <id root="test-id-3"/>
-                <id root="2.16.840.1.113883.2.1.4.5.2" extension="DUMMY"/>
-                <effectiveTime>
-                    <center value="20030221115000"/>
-                </effectiveTime>
-                <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
-                    <desc>UNKNOWN</desc>
-                </specimenSpecimenMaterial>
-            </specimenRole>
-        </specimen>
-        <component typeCode="COMP" contextConductionInd="true">
-            <NarrativeStatement classCode="OBS" moodCode="EVN">
-                <id root="test-id-3"/>
-                <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-                    CommentDate:UNK
-
-                    EMPTY REPORT</text>
-                <statusCode code="COMPLETE"/>
-                <availabilityTime nullFlavor="UNK"/>
-            </NarrativeStatement>
-        </component>
-    </CompoundStatement>
-            </component><component typeCode="COMP" contextConductionInd="true">
-        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-            <id root="test-id-3"/>
-            <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
-            <statusCode code="COMPLETE"/>
-            <effectiveTime>
-                <center nullFlavor="NI"/>
-            </effectiveTime>
-            <availabilityTime value="20030221115000"/>
-            <specimen typeCode="SPC">
-                <specimenRole classCode="SPEC">
+                <agentDirectory classCode="AGNT">
+                    <part typeCode="PART">
+                        <Agent classCode="AGNT">
+                            <id root="test-id-3"/>
+                            <code nullFlavor="UNK">
+                                <originalText>Unknown</originalText>
+                            </code>
+                            <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                                <name>
+                                    <family>TEMPLE SOWERBY MEDICAL PRACTICE</family>
+                                </name>
+                            </agentPerson>
+                        </Agent>
+                    </part>
+                    <part typeCode="PART">
+                        <Agent classCode="AGNT">
+                            <id root="test-id-3"/>
+                            <code nullFlavor="UNK">
+                                <originalText>Unknown</originalText>
+                            </code>
+                            <agentPerson classCode="PSN" determinerCode="INSTANCE">
+                                <name>
+                                    <prefix>Dr</prefix>
+                                    <given>David</given>
+                                    <family>McAvenue</family>
+                                </name>
+                            </agentPerson>
+                        </Agent>
+                    </part>
+                </agentDirectory>
+            </responsibleParty>
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
                     <id root="test-id-3"/>
-                <id root="2.16.840.1.113883.2.1.4.5.2" extension="G,03.0999008.K"/>
-                <effectiveTime>
-                    <center value="20030109000000"/>
-                </effectiveTime>
-                <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
-                    <desc>Blood</desc>
-                </specimenSpecimenMaterial>
-            </specimenRole>
-        </specimen>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="test-id-3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
-CommentDate:20030109000000
+                    <code code="109341000000100" displayName="GP to GP communication transaction"
+                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center value="20030221115000"/>
+                    </effectiveTime>
+                    <availabilityTime value="20030221115000"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20030221115000"/>
+                        <agentRef classCode="AGNT">
+                            <id nullFlavor="UNK"/>
+                        </agentRef>
+                    </author>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id nullFlavor="UNK"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                            <id root="test-id-3"/>
+                            <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                  displayName="laboratory reporting">
+                                <originalText>Filed Report</originalText>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="NI"/>
+                            </effectiveTime>
+                            <availabilityTime value="20030221115000"/>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                    <id root="test-id-3"/>
+                                    <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
+                                        CommentDate:20030221115000
 
-Received Date: 2003-01-09 13:54
-</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime value="20030221115000"/>
-    </NarrativeStatement>
-</component>
-            <component typeCode="COMP" contextConductionInd="true">
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="test-id-3"/>
-        <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-CommentDate:UNK
+                                        Status: unknown
+                                    </text>
+                                    <statusCode code="COMPLETE"/>
+                                    <availabilityTime value="20030221115000"/>
+                                </NarrativeStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                    <id root="test-id-3"/>
+                                    <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="specimen (specimen)"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20030221115000"/>
+                                    <specimen typeCode="SPC">
+                                        <specimenRole classCode="SPEC">
+                                            <id root="test-id-3"/>
+                                            <id root="2.16.840.1.113883.2.1.4.5.2" extension="DUMMY"/>
+                                            <effectiveTime>
+                                                <center value="20030221115000"/>
+                                            </effectiveTime>
+                                            <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
+                                                <desc>UNKNOWN</desc>
+                                            </specimenSpecimenMaterial>
+                                        </specimenRole>
+                                    </specimen>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="test-id-3"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                                CommentDate:UNK
 
-EMPTY REPORT</text>
-        <statusCode code="COMPLETE"/>
-        <availabilityTime nullFlavor="UNK"/>
-    </NarrativeStatement>
-</component>
-    </CompoundStatement>
-</component>
-    </CompoundStatement>
-</component>
-    </ehrComposition>
-</component>
-                <component typeCode="COMP">
-    <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-        <id root="test-id-3" />
-        <code code="109341000000100" displayName="GP to GP communication transaction" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-        <statusCode code="COMPLETE" />
-        <effectiveTime>
-            <center value="20100113"/>
-        </effectiveTime>
-        <availabilityTime value="20100113"/>
-        <author typeCode="AUT" contextControlCode="OP">
-            <time value="20100113" />
-            <agentRef classCode="AGNT">
-                <id root="test-id-3" />
-            </agentRef>
-        </author>
-        <Participant2 typeCode="PRF" contextControlCode="OP">
-            <agentRef classCode="AGNT">
-                <id root="test-id-3"/>
-            </agentRef>
-        </Participant2>
-        <component typeCode="COMP" >
-    <NarrativeStatement classCode="OBS" moodCode="EVN">
-        <id root="test-id-3" />
-        <text>This is some random free text</text>
-        <statusCode code="COMPLETE" />
-        <availabilityTime value="20100113" />
-        <Participant typeCode="PRF" contextControlCode="OP">
-    <agentRef classCode="AGNT">
-        <id root="test-id-3"/>
-    </agentRef>
-</Participant>
-    </NarrativeStatement>
-</component>
-    </ehrComposition>
-</component>
-                <component typeCode="COMP">
-    <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-        <id root="test-id-3" />
-        <code code="196401000000100" displayName="Non-consultation data" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
-        <statusCode code="COMPLETE" />
-        <effectiveTime>
-            <center nullFlavor="UNK"/>
-        </effectiveTime>
-        <availabilityTime nullFlavor="UNK"/>
-        <author typeCode="AUT" contextControlCode="OP">
-            <time nullFlavor="UNK" />
-            <agentRef classCode="AGNT">
-                <id root="test-id-3" />
-            </agentRef>
-        </author>
-        <Participant2 typeCode="PRF" contextControlCode="OP">
-            <agentRef classCode="AGNT">
-                <id root="test-id-3"/>
-            </agentRef>
-        </Participant2>
-        <component typeCode="COMP" >
-    <ObservationStatement classCode="OBS" moodCode="EVN">
-        <id root="test-id-3" />
-        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
-        <statusCode code="COMPLETE" />
-        <effectiveTime>
-            <center nullFlavor="UNK"/>
-        </effectiveTime>
-        <availabilityTime nullFlavor="UNK"/>
+                                                EMPTY REPORT
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime nullFlavor="UNK"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                            <component typeCode="COMP" contextConductionInd="true">
+                                <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+                                    <id root="test-id-3"/>
+                                    <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                                          displayName="specimen (specimen)"/>
+                                    <statusCode code="COMPLETE"/>
+                                    <effectiveTime>
+                                        <center nullFlavor="NI"/>
+                                    </effectiveTime>
+                                    <availabilityTime value="20030221115000"/>
+                                    <specimen typeCode="SPC">
+                                        <specimenRole classCode="SPEC">
+                                            <id root="test-id-3"/>
+                                            <id root="2.16.840.1.113883.2.1.4.5.2" extension="G,03.0999008.K"/>
+                                            <effectiveTime>
+                                                <center value="20030109000000"/>
+                                            </effectiveTime>
+                                            <specimenSpecimenMaterial determinerCode="INSTANCE" classCode="MAT">
+                                                <desc>Blood</desc>
+                                            </specimenSpecimenMaterial>
+                                        </specimenRole>
+                                    </specimen>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="test-id-3"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
+                                                CommentDate:20030109000000
+
+                                                Received Date: 2003-01-09 13:54
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime value="20030221115000"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                    <component typeCode="COMP" contextConductionInd="true">
+                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                                            <id root="test-id-3"/>
+                                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
+                                                CommentDate:UNK
+
+                                                EMPTY REPORT
+                                            </text>
+                                            <statusCode code="COMPLETE"/>
+                                            <availabilityTime nullFlavor="UNK"/>
+                                        </NarrativeStatement>
+                                    </component>
+                                </CompoundStatement>
+                            </component>
+                        </CompoundStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="test-id-3"/>
+                    <code code="109341000000100" displayName="GP to GP communication transaction"
+                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center value="20100113"/>
+                    </effectiveTime>
+                    <availabilityTime value="20100113"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time value="20100113"/>
+                        <agentRef classCode="AGNT">
+                            <id root="test-id-3"/>
+                        </agentRef>
+                    </author>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="test-id-3"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <NarrativeStatement classCode="OBS" moodCode="EVN">
+                            <id root="test-id-3"/>
+                            <text>This is some random free text</text>
+                            <statusCode code="COMPLETE"/>
+                            <availabilityTime value="20100113"/>
+                            <Participant typeCode="PRF" contextControlCode="OP">
+                                <agentRef classCode="AGNT">
+                                    <id root="test-id-3"/>
+                                </agentRef>
+                            </Participant>
+                        </NarrativeStatement>
+                    </component>
+                </ehrComposition>
+            </component>
+            <component typeCode="COMP">
+                <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+                    <id root="test-id-3"/>
+                    <code code="196401000000100" displayName="Non-consultation data"
+                          codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                    <statusCode code="COMPLETE"/>
+                    <effectiveTime>
+                        <center nullFlavor="UNK"/>
+                    </effectiveTime>
+                    <availabilityTime nullFlavor="UNK"/>
+                    <author typeCode="AUT" contextControlCode="OP">
+                        <time nullFlavor="UNK"/>
+                        <agentRef classCode="AGNT">
+                            <id root="test-id-3"/>
+                        </agentRef>
+                    </author>
+                    <Participant2 typeCode="PRF" contextControlCode="OP">
+                        <agentRef classCode="AGNT">
+                            <id root="test-id-3"/>
+                        </agentRef>
+                    </Participant2>
+                    <component typeCode="COMP">
+                        <ObservationStatement classCode="OBS" moodCode="EVN">
+                            <id root="test-id-3"/>
+                            <code nullFlavor="UNK">
+                                <originalText>Mocked code</originalText>
+                            </code>
+                            <statusCode code="COMPLETE"/>
+                            <effectiveTime>
+                                <center nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <availabilityTime nullFlavor="UNK"/>
 
 
-        <pertinentInformation typeCode="PERT">
-            <sequenceNumber value="+1" />
-            <pertinentAnnotation classCode="OBS" moodCode="EVN">
-                <text></text>
-            </pertinentAnnotation>
-        </pertinentInformation>
+                            <pertinentInformation typeCode="PERT">
+                                <sequenceNumber value="+1"/>
+                                <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                                    <text></text>
+                                </pertinentAnnotation>
+                            </pertinentInformation>
 
-        <Participant typeCode="PRF" contextControlCode="OP">
-    <agentRef classCode="AGNT">
-        <id root="test-id-3"/>
-    </agentRef>
-</Participant>
-    </ObservationStatement>
-</component>
-    </ehrComposition>
-</component>
+                            <Participant typeCode="PRF" contextControlCode="OP">
+                                <agentRef classCode="AGNT">
+                                    <id root="test-id-3"/>
+                                </agentRef>
+                            </Participant>
+                        </ObservationStatement>
+                    </component>
+                </ehrComposition>
+            </component>
         </ehrFolder>
     </component>
     <inFulfillmentOf typeCode="FLFS">
         <priorEhrRequest classCode="EXTRACT" moodCode="RQO">
-            <id root="test-request-id" />
+            <id root="test-request-id"/>
         </priorEhrRequest>
     </inFulfillmentOf>
     <limitation typeCode="LIMIT" inversionInd="true">
         <limitingEhrExtractSpecification classCode="OBS" moodCode="DEF">
-            <id root="76C49C11-5271-11EA-9384-E83935108FD5" />
-            <code code="37241000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Entire record available to originator (administrative concept)" />
+            <id root="76C49C11-5271-11EA-9384-E83935108FD5"/>
+            <code code="37241000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"
+                  displayName="Entire record available to originator (administrative concept)"/>
         </limitingEhrExtractSpecification>
     </limitation>
 </EhrExtract>

--- a/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-standalone-observations.xml
+++ b/service/src/test/resources/ehr/request/fhir/output/expected-xml-with-standalone-observations.xml
@@ -180,21 +180,11 @@
                                                 CommentDate:20030109000000
 
                                                 Received Date: 2003-01-09 13:54
+
+                                                EMPTY SPECIMEN
                                             </text>
                                             <statusCode code="COMPLETE"/>
                                             <availabilityTime value="20030221115000"/>
-                                        </NarrativeStatement>
-                                    </component>
-                                    <component typeCode="COMP" contextConductionInd="true">
-                                        <NarrativeStatement classCode="OBS" moodCode="EVN">
-                                            <id root="test-id-3"/>
-                                            <text mediaType="text/x-h7uk-pmip">CommentType:AGGREGATE COMMENT SET
-                                                CommentDate:UNK
-
-                                                EMPTY REPORT
-                                            </text>
-                                            <statusCode code="COMPLETE"/>
-                                            <availabilityTime nullFlavor="UNK"/>
                                         </NarrativeStatement>
                                     </component>
                                 </CompoundStatement>


### PR DESCRIPTION
## What

Changed `DiagnosticReportMapper` to not send duplicated Test Reports to `SpecimenMapper`

## Why

Duplicated test reports were appearing in the generated xml.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
