### PR TITLE
Enforcing strict error handling while converting json tests

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseService.java
@@ -26,7 +26,6 @@ public class FhirParseService {
 
     private IParser prepareParser() {
         FhirContext ctx = FhirContext.forDstu3();
-        ctx.newJsonParser();
         ctx.setParserErrorHandler(new StrictErrorHandler());
         return ctx.newJsonParser();
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseServiceTest.java
@@ -1,6 +1,5 @@
 package uk.nhs.adaptors.gp2gp.common.service;
 
-import ca.uhn.fhir.parser.DataFormatException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseServiceTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.gp2gp.common.service;
 
+import ca.uhn.fhir.parser.DataFormatException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +43,32 @@ class FhirParseServiceTest {
                                                       details,
                                                       diagnostics);
         fhirParseService = new FhirParseService();
+    }
+
+    @Test
+    void shouldThrowValidationExceptionForInvalidJsonDiagnosticsField() {
+
+        String invalidJson = "{\n"
+                             + "  \"resourceType\": \"OperationOutcome\",\n"
+                             + "  \"meta\": {\n"
+                             + "    \"profile\": [ \"https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1\" ]\n"
+                             + "  },\n"
+                             + "  \"issue\": [ {\n"
+                             + "    \"severity\": \"error\",\n"
+                             + "    \"code\": \"value\",\n"
+                             + "    \"details\": {\n"
+                             + "      \"coding\": [ {\n"
+                             + "        \"system\": \"http://fhir.nhs.net/ValueSet/gpconnect-error-or-warning-code-1\",\n"
+                             + "        \"code\": \"INVALID_IDENTIFIER_VALUE\"\n"
+                             + "      } ]\n"
+                             + "    },\n"
+                             + "    \"diagnosticos\": \"Provide a conversationId that exists and retry the operation\"\n"
+                             + "  } ]\n"
+                             + "}";
+
+        assertThrows(FhirValidationException.class, () -> {
+            fhirParseService.parseResource(invalidJson, OperationOutcome.class);
+        });
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/FhirParseServiceTest.java
@@ -47,23 +47,25 @@ class FhirParseServiceTest {
     @Test
     void shouldThrowValidationExceptionForInvalidJsonDiagnosticsField() {
 
-        String invalidJson = "{\n"
-                             + "  \"resourceType\": \"OperationOutcome\",\n"
-                             + "  \"meta\": {\n"
-                             + "    \"profile\": [ \"https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1\" ]\n"
-                             + "  },\n"
-                             + "  \"issue\": [ {\n"
-                             + "    \"severity\": \"error\",\n"
-                             + "    \"code\": \"value\",\n"
-                             + "    \"details\": {\n"
-                             + "      \"coding\": [ {\n"
-                             + "        \"system\": \"http://fhir.nhs.net/ValueSet/gpconnect-error-or-warning-code-1\",\n"
-                             + "        \"code\": \"INVALID_IDENTIFIER_VALUE\"\n"
-                             + "      } ]\n"
-                             + "    },\n"
-                             + "    \"diagnosticos\": \"Provide a conversationId that exists and retry the operation\"\n"
-                             + "  } ]\n"
-                             + "}";
+        String invalidJson = """
+                             {
+                             "resourceType": "OperationOutcome",
+                             "meta": {
+                                "profile": ["https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-OperationOutcome-1"]
+                             },
+                             "issue": [ {
+                                "severity": "error",
+                                "code": "value",
+                                "details": {
+                                    "coding": [ {
+                                        "system": "http://fhir.nhs.net/ValueSet/gpconnect-error-or-warning-code-1",
+                                        "code": "INVALID_IDENTIFIER_VALUE"
+                                    } ]
+                                },
+                                "diagnosticos": "Provide a conversationId that exists and retry the operation"
+                             } ]
+                             }
+                             """;
 
         assertThrows(FhirValidationException.class, () -> {
             fhirParseService.parseResource(invalidJson, OperationOutcome.class);


### PR DESCRIPTION
## What

Enforcing strict error handling while converting json tests

## Why

JSON converter in FhirParseService can convert objects in strict error handler mode or non-strict. In GP2GP adaptor we use the strict mode hence adding tests to confirm that. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
