### PR TITLE
Also clear the ehrExtractStatus.error field before resending EHR

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrResendController.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/EhrResendController.java
@@ -103,6 +103,7 @@ public class EhrResendController {
         ehrExtractStatus.setGpcAccessDocument(null);
         ehrExtractStatus.setEhrContinue(null);
         ehrExtractStatus.setEhrReceivedAcknowledgement(null);
+        ehrExtractStatus.setError(null);
 
         return ehrExtractStatus;
     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrResendControllerTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/EhrResendControllerTest.java
@@ -102,6 +102,7 @@ class EhrResendControllerTest {
         ehrExtractStatus.setEhrContinue(EhrExtractStatus.EhrContinue.builder().build());
         ehrExtractStatus.setGpcAccessDocument(EhrExtractStatus.GpcAccessDocument.builder().build());
         ehrExtractStatus.setCreated(FIVE_DAYS_AGO);
+        ehrExtractStatus.setError(EhrExtractStatus.Error.builder().message("Failed to download EHR").build());
 
         when(ehrExtractStatusRepository.findByConversationId(CONVERSATION_ID)).thenReturn(Optional.of(ehrExtractStatus));
 
@@ -122,7 +123,8 @@ class EhrResendControllerTest {
             () -> assertNull(ehrExtractStatus.getEhrContinue()),
             () -> assertNull(ehrExtractStatus.getAckPending()),
             () -> assertNull(ehrExtractStatus.getEhrReceivedAcknowledgement()),
-            () -> assertNull(ehrExtractStatus.getGpcAccessDocument())
+            () -> assertNull(ehrExtractStatus.getGpcAccessDocument()),
+            () -> assertNull(ehrExtractStatus.getError())
         );
     }
 


### PR DESCRIPTION
## Why

When an error happens on the adaptor when fetching the Structured Record, the EHR error field will be populated.

Clear this, as otherwise the ProcessFailureHandlingService.hasProcessFailed check will return true.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
